### PR TITLE
fix bug

### DIFF
--- a/R/R/loonGrob.R
+++ b/R/R/loonGrob.R
@@ -1019,7 +1019,7 @@ xy_coords_layer <- function(layer, native_unit = TRUE) {
     )
   } else if(type == "histogram"){
     list(
-      x = l_cget(layer, "x"),
+      x = l_cget(widget, "x"),
       y = NA
     )
   } else {


### PR DESCRIPTION
It should be `l_cget(widget, "x")` instead of `layer`. It is an error, but it never happens due to `loonGrob_l_layer_histogram` does not call function `get_layer_states`.