### PR TITLE
Try to fix several uplevel usages

### DIFF
--- a/R/inst/tcl/loon/library/oo_Decorated_View.tcl
+++ b/R/inst/tcl/loon/library/oo_Decorated_View.tcl
@@ -58,7 +58,7 @@
 	    
 	    set ns [info object namespace $Model] 
 	    foreach state $dv_soi {
-		set ${state}_var [uplevel #0 ${ns}::my varname $state]
+		set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	    }
 
 	    set showScales [set $showScales_var]

--- a/R/inst/tcl/loon/library/oo_GraphWorldviewVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_GraphWorldviewVisual.tcl
@@ -44,7 +44,7 @@
 	my variable canvas visualid idEdges ids
 	
 	
-	uplevel #0 [$canvas delete "layer&&$visualid"]
+	uplevel #0 [list $canvas delete "layer&&$visualid"]
 	
 	set idEdges {}
 	set ids {}

--- a/R/inst/tcl/loon/library/oo_Graphswitch.tcl
+++ b/R/inst/tcl/loon/library/oo_Graphswitch.tcl
@@ -269,7 +269,7 @@ oo::class create loon::classes::Graphswitch {
 			-to [lindex $G 2]\
 			-isDirected [lindex $G 3]]
 	
-	uplevel #0 [$activewidget scaleto world]
+	uplevel #0 [list $activewidget scaleto world]
     }
 
     method ActivewidgetToTreeview {id} {

--- a/R/inst/tcl/loon/library/oo_HistogramInspectorAnalysis.tcl
+++ b/R/inst/tcl/loon/library/oo_HistogramInspectorAnalysis.tcl
@@ -324,7 +324,7 @@ oo::class create loon::classes::HistogramInspectorAnalysis {
 	set i [lindex [$canvas gettags current] 2]
 	set sel_color [$canvas itemcget "color && inner && $i" -fill]
 	
-	set color [uplevel #0 $activewidget cget -color]
+	set color [uplevel #0 [list $activewidget cget -color]]
 	
 	if {$add} {
 	    set selected [uplevel #0 [list $activewidget cget -selected]]

--- a/R/inst/tcl/loon/library/oo_HistogramVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_HistogramVisual.tcl
@@ -215,7 +215,7 @@
 			    continue
 			}
 			set newcount [expr {$previousCount + $count}]
-			uplevel #0 [$canvas coords [dict get $vals $col]\
+			uplevel #0 [list $canvas coords [dict get $vals $col]\
 					[$map mapDxy2Scoords $xrange\
 					     [list $previousCount $newcount]]]
 			
@@ -224,12 +224,12 @@
 		    
 		}
 	    } else {
-		uplevel #0 [$canvas coords [dict get $vals allFill] $coordsAll]
+		uplevel #0 [list $canvas coords [dict get $vals allFill] $coordsAll]
 		
 		set count_selected  [dict get $bins bin $id count selected]
 		
 		if {$count_selected > 0} {
-		    uplevel #0 [$canvas coords [dict get $vals selected]\
+		    uplevel #0 [list $canvas coords [dict get $vals selected]\
 				    [$map mapDxy2Scoords $xrange\
 					 [list 0 $count_selected]]]
 		}
@@ -240,7 +240,7 @@
 	    
 	
 	    if {$showOutlines} {
-		uplevel #0 [$canvas coords [dict get $vals allOutline] $coordsAll]
+		uplevel #0 [list $canvas coords [dict get $vals allOutline] $coordsAll]
 	    }
 	}
 

--- a/R/inst/tcl/loon/library/oo_HistogramVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_HistogramVisual.tcl
@@ -20,7 +20,7 @@
 	
 	foreach state {count bins binwidth origin color colorStackingOrder\
 			   showOutlines showStackedColors showBinHandle colorFill colorOutline} {
-	    set ${state}_var [uplevel #0 ${modelns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${modelns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_Histogram_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_Histogram_Controller.tcl
@@ -48,7 +48,7 @@
 		if {[$model cget -yshows] eq "density"} {
 		    $model scaleto world
 		}
-		uplevel #0 [update idletasks]
+		update idletasks
 	    }
 	    binwidth {
 		set bw [lindex [$map mapS2D $x $y] 0]
@@ -58,7 +58,7 @@
 		    if {[$model cget -yshows] eq "density"} {
 			$model scaleto world
 		    }
-		    uplevel #0 [update idletasks]
+		    update idletasks
 		}
 	    }
 	    default {

--- a/R/inst/tcl/loon/library/oo_ItemLabel_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_ItemLabel_Controller.tcl
@@ -35,7 +35,7 @@
 	
 	set ns [info object namespace $Model] 
 	foreach state {showItemLabels itemLabel} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}       	
 	
 	next $Model

--- a/R/inst/tcl/loon/library/oo_LayerVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_LayerVisual.tcl
@@ -20,7 +20,7 @@
 	}
 	
 	foreach state {x y tag} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	my MakeStateBinding

--- a/R/inst/tcl/loon/library/oo_LayerVisual1.tcl
+++ b/R/inst/tcl/loon/library/oo_LayerVisual1.tcl
@@ -10,7 +10,7 @@
 	set id "noinit"
 
 	set ns [info object namespace $Layerobj]
-	set type_var [uplevel #0 ${ns}::my varname type]
+	set type_var [uplevel #0 [list ${ns}::my varname type]]
 	
 	next $Layerobj {*}$args	
     }

--- a/R/inst/tcl/loon/library/oo_LayerVisualN.tcl
+++ b/R/inst/tcl/loon/library/oo_LayerVisualN.tcl
@@ -11,9 +11,9 @@
 	set ids "noinit"
 
 	set ns [info object namespace $Layerobj]	
-	set n_var [uplevel #0 ${ns}::my varname n]
-	set active_var [uplevel #0 ${ns}::my varname active]
-	set type_var [uplevel #0 ${ns}::my varname type]
+	set n_var [uplevel #0 [list ${ns}::my varname n]]
+	set active_var [uplevel #0 [list ${ns}::my varname active]]
+	set type_var [uplevel #0 [list ${ns}::my varname type]]
 	
 	next $Layerobj {*}$args	
     }

--- a/R/inst/tcl/loon/library/oo_Layered_View.tcl
+++ b/R/inst/tcl/loon/library/oo_Layered_View.tcl
@@ -135,10 +135,10 @@
 #	    }
 #	    set siblings [$plotModel layer getSiblings $a]
 #	    if {[lindex $siblings 0] ne ""} {
-#		uplevel #0 $canvas lower $layer [lindex $siblings 0]
+#		uplevel #0 [list $canvas lower $layer [lindex $siblings 0]]
 #		break
 #	    } elseif {[lindex $siblings 1] ne ""} {
-#		uplevel #0 $canvas raise $layer [lindex $siblings 1]
+#		uplevel #0 [list $canvas raise $layer [lindex $siblings 1]]
 #		break
 #	    } 
 #	}

--- a/R/inst/tcl/loon/library/oo_LineVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_LineVisual.tcl
@@ -11,7 +11,7 @@
 	## n-1 is here number of lines
 	set ns [info object namespace $Layerobj]	
 	foreach state {color linewidth dash n} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_LinesVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_LinesVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth dash} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_NavigatorVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_NavigatorVisual.tcl
@@ -12,8 +12,8 @@
 	set navigatorId $NavigatorId
 	set navigatorObj $NavigatorObj
 	
-	set color_var [uplevel #0 ${navigatorObj}::my varname color]
-	set label_var [uplevel #0 ${navigatorObj}::my varname label]
+	set color_var [uplevel #0 [list ${navigatorObj}::my varname color]]
+	set label_var [uplevel #0 [list ${navigatorObj}::my varname label]]
 
 	next {*}${args}	
     }

--- a/R/inst/tcl/loon/library/oo_Plot_View.tcl
+++ b/R/inst/tcl/loon/library/oo_Plot_View.tcl
@@ -103,11 +103,11 @@
 	    set ns [info object namespace $plotModel] 
 	    
 	    foreach state {panX panY zoomX zoomY deltaX deltaY} {
-		set ${state}_var [uplevel #0 ${ns}::my varname $state]
+		set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 		$map set[string toupper $state 0] [set [set ${state}_var]]
 	    }
-	    set background_var [uplevel #0 ${ns}::my varname background]
-	    set swap_var [uplevel #0 ${ns}::my varname swapAxes]
+	    set background_var [uplevel #0 [list ${ns}::my varname background]]
+	    set swap_var [uplevel #0 [list ${ns}::my varname swapAxes]]
 	    $map setSwap [set $swap_var]
 
 	    uplevel #0 [list $canvas configure -background [set $background_var]]

--- a/R/inst/tcl/loon/library/oo_PointrangeGlyphVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_PointrangeGlyphVisual.tcl
@@ -11,11 +11,11 @@ oo::class create loon::classes::PointrangeGlyphVisual {
 	
 	set ns [info object namespace $glyphObj]
 	
- 	set ymin_var [uplevel #0 ${ns}::my varname ymin]
-	set ymax_var [uplevel #0 ${ns}::my varname ymax]
-	set linewidth_var [uplevel #0 ${ns}::my varname linewidth]
+ 	set ymin_var [uplevel #0 [list ${ns}::my varname ymin]]
+	set ymax_var [uplevel #0 [list ${ns}::my varname ymax]]
+	set linewidth_var [uplevel #0 [list ${ns}::my varname linewidth]]
 	
-	set swap_var [uplevel #0 [info object namespace $map]::my varname swap]
+	set swap_var [uplevel #0 [list [info object namespace $map]::my varname swap]]
 	set y_var $yvar
 		
     }

--- a/R/inst/tcl/loon/library/oo_PointsVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_PointsVisual.tcl
@@ -9,7 +9,7 @@
 	
 	set ns [info object namespace $Layerobj]	
 	foreach state {color size linecolor linewidth} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_PolygonGlyphVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_PolygonGlyphVisual.tcl
@@ -22,8 +22,8 @@ oo::class create loon::classes::PolygonGlyphVisual {
 	my variable glyphObject
 	
 	
-	set id [uplevel #0 $canvas create polygon 0 0 0 0\
-		    -width [lindex [set $linewidth_var] $ind]]
+	set id [uplevel #0 [list $canvas create polygon 0 0 0 0\
+		    -width [lindex [set $linewidth_var] $ind]]]
 	
 	return $id
     }

--- a/R/inst/tcl/loon/library/oo_PolygonVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_PolygonVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth linecolor} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_PolygonsVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_PolygonsVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth linecolor} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 
 	next $Layerobj {*}$args

--- a/R/inst/tcl/loon/library/oo_Rotate3D_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_Rotate3D_Controller.tcl
@@ -14,7 +14,7 @@
         set rotateIndicator -1
 
         set ns [info object namespace $view]
-        set map [set [uplevel #0 ${ns}::my varname map]]
+        set map [set [uplevel #0 [list ${ns}::my varname map]]]
 
         next $view
 

--- a/R/inst/tcl/loon/library/oo_Scatterplot3D_View.tcl
+++ b/R/inst/tcl/loon/library/oo_Scatterplot3D_View.tcl
@@ -26,7 +26,7 @@
         next $Model
         set ns [info object namespace $plotModel] 
         foreach state {rotate3DX rotate3DY} {
-            set ${state}_var [uplevel #0 ${ns}::my varname $state]
+            set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
             $map set[string toupper $state 0] [set [set ${state}_var]]
         }
         $controller setModel $Model

--- a/R/inst/tcl/loon/library/oo_ScatterplotVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_ScatterplotVisual.tcl
@@ -27,7 +27,7 @@
 
 	foreach state {n color size selected active xTemp yTemp\
 			   glyph glyphZoomSensitivity foreground} {
-	    set ${state}_var [uplevel #0 ${modelns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${modelns}::my varname $state]]
 	}
 	
 
@@ -523,8 +523,8 @@
 	if {$value} {
 	    my redraw
 	} else {
-	    set tmp [uplevel #0 $canvas create oval 0 0 0 0 -state hidden]
-	    uplevel #0 $canvas lower $tmp $visualid
+	    set tmp [uplevel #0 [list $canvas create oval 0 0 0 0 -state hidden]]
+	    uplevel #0 [list $canvas lower $tmp $visualid]
 	    my clear
 	    set ids $tmp
 	}       	

--- a/R/inst/tcl/loon/library/oo_SerialaxesInspectorAnalysis.tcl
+++ b/R/inst/tcl/loon/library/oo_SerialaxesInspectorAnalysis.tcl
@@ -296,7 +296,7 @@ oo::class create loon::classes::SerialaxesInspectorAnalysis {
 	set i [lindex [$canvas gettags current] 2]
 	set sel_color [$canvas itemcget "color && inner && $i" -fill]
 	
-	set color [uplevel #0 $activewidget cget -color]
+	set color [uplevel #0 [list $activewidget cget -color]]
 	
 	if {$add} {
 	    set selected [uplevel #0 [list $activewidget cget -selected]]

--- a/R/inst/tcl/loon/library/oo_SpiroGlyphVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_SpiroGlyphVisual.tcl
@@ -21,8 +21,8 @@ oo::class create loon::classes::SpiroGlyphVisual {
 	my variable glyphObject
 	
 	
-	set id [uplevel #0 $canvas create line 0 0 0 0\
-		    -width [lindex [set $linewidth_var] $ind]]
+	set id [uplevel #0 [list $canvas create line 0 0 0 0\
+		    -width [lindex [set $linewidth_var] $ind]]]
 	
 	return $id
     }

--- a/R/inst/tcl/loon/library/oo_SweepBrush_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_SweepBrush_Controller.tcl
@@ -21,7 +21,7 @@
 	set modelLayer ""
 	set bp_modelStateBinding ""
 	
-	set viewMap [set [uplevel #0 [info object namespace $view]::my varname map]]
+	set viewMap [set [uplevel #0 [list [info object namespace $view]::my varname map]]]
 	
 	next $view
 	
@@ -53,7 +53,7 @@
 
 	set ns [info object namespace $Model] 
 	foreach state $sb_soi {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	set modelLayer ""

--- a/R/inst/tcl/loon/library/oo_TempMove_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_TempMove_Controller.tcl
@@ -19,7 +19,7 @@
 	    set ${state}_var ""
 	}
 	
-	set viewMap [set [uplevel #0 [info object namespace $view]::my varname map]]
+	set viewMap [set [uplevel #0 [list [info object namespace $view]::my varname map]]]
 	
 	next $view
 	
@@ -32,7 +32,7 @@
 
 	set ns [info object namespace $Model] 
 	foreach state $tm_soi {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Model

--- a/R/inst/tcl/loon/library/oo_TextVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_TextVisual.tcl
@@ -10,7 +10,7 @@
 
 	set ns [info object namespace $Layerobj]	
 	foreach state {color size text angle anchor justify} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args	

--- a/R/inst/tcl/loon/library/oo_TextsVisual.tcl
+++ b/R/inst/tcl/loon/library/oo_TextsVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]	
 	foreach state {text anchor justify angle} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args	

--- a/R/inst/tcl/loon/library/oo_WorldviewMap.tcl
+++ b/R/inst/tcl/loon/library/oo_WorldviewMap.tcl
@@ -27,7 +27,7 @@ oo::class create loon::classes::WorldviewMap {
 	    set modelns [info object namespace $model]
 	    
 	    foreach var {panX panY zoomX zoomY} {
-		set ${var}_var [uplevel #0 ${modelns}::my varname $var]
+		set ${var}_var [uplevel #0 [list ${modelns}::my varname $var]]
 	    }
 	}
     }

--- a/R/inst/tcl/loon/library/oo_ZoomPan_Controller.tcl
+++ b/R/inst/tcl/loon/library/oo_ZoomPan_Controller.tcl
@@ -15,7 +15,7 @@
 	set zoomInFactor 1.1
 	
 	set ns [info object namespace $view]
-	set map [set [uplevel #0 ${ns}::my varname map]]
+	set map [set [uplevel #0 [list ${ns}::my varname map]]]
 
 	next $view
 	

--- a/R/inst/tcl/loon/library/x_synchronize.tcl
+++ b/R/inst/tcl/loon/library/x_synchronize.tcl
@@ -332,7 +332,7 @@ namespace eval loon {
     proc hasModelLinkedMembers {model} {
 	variable LinkingG2M
 	
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	
 	return [::loon::hasGroupLinkedMembers $group $model]
     }
@@ -343,7 +343,7 @@ namespace eval loon {
 	variable LinkingG2M
 	variable LinkingM2G
 
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	
 	unmapModelFromGroup $model
 	lappend LinkingG2M($group) $model
@@ -408,7 +408,7 @@ namespace eval loon {
     proc numberOfLinkedModels {model} {
 	variable LinkingG2M
 	
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	set linkedModels $LinkingG2M($group)
 	
 	set i [lsearch -exact $linkedModels $model]

--- a/Tcl/library/oo_Decorated_View.tcl
+++ b/Tcl/library/oo_Decorated_View.tcl
@@ -58,7 +58,7 @@
 	    
 	    set ns [info object namespace $Model] 
 	    foreach state $dv_soi {
-		set ${state}_var [uplevel #0 ${ns}::my varname $state]
+		set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	    }
 
 	    set showScales [set $showScales_var]

--- a/Tcl/library/oo_GraphWorldviewVisual.tcl
+++ b/Tcl/library/oo_GraphWorldviewVisual.tcl
@@ -44,7 +44,7 @@
 	my variable canvas visualid idEdges ids
 	
 	
-	uplevel #0 [$canvas delete "layer&&$visualid"]
+	uplevel #0 [list $canvas delete "layer&&$visualid"]
 	
 	set idEdges {}
 	set ids {}

--- a/Tcl/library/oo_Graphswitch.tcl
+++ b/Tcl/library/oo_Graphswitch.tcl
@@ -269,7 +269,7 @@ oo::class create loon::classes::Graphswitch {
 			-to [lindex $G 2]\
 			-isDirected [lindex $G 3]]
 	
-	uplevel #0 [$activewidget scaleto world]
+	uplevel #0 [list $activewidget scaleto world]
     }
 
     method ActivewidgetToTreeview {id} {

--- a/Tcl/library/oo_HistogramInspectorAnalysis.tcl
+++ b/Tcl/library/oo_HistogramInspectorAnalysis.tcl
@@ -324,7 +324,7 @@ oo::class create loon::classes::HistogramInspectorAnalysis {
 	set i [lindex [$canvas gettags current] 2]
 	set sel_color [$canvas itemcget "color && inner && $i" -fill]
 	
-	set color [uplevel #0 $activewidget cget -color]
+	set color [uplevel #0 [list $activewidget cget -color]]
 	
 	if {$add} {
 	    set selected [uplevel #0 [list $activewidget cget -selected]]

--- a/Tcl/library/oo_HistogramVisual.tcl
+++ b/Tcl/library/oo_HistogramVisual.tcl
@@ -215,7 +215,7 @@
 			    continue
 			}
 			set newcount [expr {$previousCount + $count}]
-			uplevel #0 [$canvas coords [dict get $vals $col]\
+			uplevel #0 [list $canvas coords [dict get $vals $col]\
 					[$map mapDxy2Scoords $xrange\
 					     [list $previousCount $newcount]]]
 			
@@ -224,12 +224,12 @@
 		    
 		}
 	    } else {
-		uplevel #0 [$canvas coords [dict get $vals allFill] $coordsAll]
+		uplevel #0 [list $canvas coords [dict get $vals allFill] $coordsAll]
 		
 		set count_selected  [dict get $bins bin $id count selected]
 		
 		if {$count_selected > 0} {
-		    uplevel #0 [$canvas coords [dict get $vals selected]\
+		    uplevel #0 [list $canvas coords [dict get $vals selected]\
 				    [$map mapDxy2Scoords $xrange\
 					 [list 0 $count_selected]]]
 		}
@@ -240,7 +240,7 @@
 	    
 	
 	    if {$showOutlines} {
-		uplevel #0 [$canvas coords [dict get $vals allOutline] $coordsAll]
+		uplevel #0 [list $canvas coords [dict get $vals allOutline] $coordsAll]
 	    }
 	}
 

--- a/Tcl/library/oo_HistogramVisual.tcl
+++ b/Tcl/library/oo_HistogramVisual.tcl
@@ -20,7 +20,7 @@
 	
 	foreach state {count bins binwidth origin color colorStackingOrder\
 			   showOutlines showStackedColors showBinHandle colorFill colorOutline} {
-	    set ${state}_var [uplevel #0 ${modelns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${modelns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_Histogram_Controller.tcl
+++ b/Tcl/library/oo_Histogram_Controller.tcl
@@ -48,7 +48,7 @@
 		if {[$model cget -yshows] eq "density"} {
 		    $model scaleto world
 		}
-		uplevel #0 [update idletasks]
+		update idletasks
 	    }
 	    binwidth {
 		set bw [lindex [$map mapS2D $x $y] 0]
@@ -58,7 +58,7 @@
 		    if {[$model cget -yshows] eq "density"} {
 			$model scaleto world
 		    }
-		    uplevel #0 [update idletasks]
+		    update idletasks
 		}
 	    }
 	    default {

--- a/Tcl/library/oo_ItemLabel_Controller.tcl
+++ b/Tcl/library/oo_ItemLabel_Controller.tcl
@@ -35,7 +35,7 @@
 	
 	set ns [info object namespace $Model] 
 	foreach state {showItemLabels itemLabel} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}       	
 	
 	next $Model

--- a/Tcl/library/oo_LayerVisual.tcl
+++ b/Tcl/library/oo_LayerVisual.tcl
@@ -20,7 +20,7 @@
 	}
 	
 	foreach state {x y tag} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	my MakeStateBinding

--- a/Tcl/library/oo_LayerVisual1.tcl
+++ b/Tcl/library/oo_LayerVisual1.tcl
@@ -10,7 +10,7 @@
 	set id "noinit"
 
 	set ns [info object namespace $Layerobj]
-	set type_var [uplevel #0 ${ns}::my varname type]
+	set type_var [uplevel #0 [list ${ns}::my varname type]]
 	
 	next $Layerobj {*}$args	
     }

--- a/Tcl/library/oo_LayerVisualN.tcl
+++ b/Tcl/library/oo_LayerVisualN.tcl
@@ -11,9 +11,9 @@
 	set ids "noinit"
 
 	set ns [info object namespace $Layerobj]	
-	set n_var [uplevel #0 ${ns}::my varname n]
-	set active_var [uplevel #0 ${ns}::my varname active]
-	set type_var [uplevel #0 ${ns}::my varname type]
+	set n_var [uplevel #0 [list ${ns}::my varname n]]
+	set active_var [uplevel #0 [list ${ns}::my varname active]]
+	set type_var [uplevel #0 [list ${ns}::my varname type]]
 	
 	next $Layerobj {*}$args	
     }

--- a/Tcl/library/oo_Layered_View.tcl
+++ b/Tcl/library/oo_Layered_View.tcl
@@ -135,10 +135,10 @@
 #	    }
 #	    set siblings [$plotModel layer getSiblings $a]
 #	    if {[lindex $siblings 0] ne ""} {
-#		uplevel #0 $canvas lower $layer [lindex $siblings 0]
+#		uplevel #0 [list $canvas lower $layer [lindex $siblings 0]]
 #		break
 #	    } elseif {[lindex $siblings 1] ne ""} {
-#		uplevel #0 $canvas raise $layer [lindex $siblings 1]
+#		uplevel #0 [list $canvas raise $layer [lindex $siblings 1]]
 #		break
 #	    } 
 #	}

--- a/Tcl/library/oo_LineVisual.tcl
+++ b/Tcl/library/oo_LineVisual.tcl
@@ -11,7 +11,7 @@
 	## n-1 is here number of lines
 	set ns [info object namespace $Layerobj]	
 	foreach state {color linewidth dash n} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_LinesVisual.tcl
+++ b/Tcl/library/oo_LinesVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth dash} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_NavigatorVisual.tcl
+++ b/Tcl/library/oo_NavigatorVisual.tcl
@@ -12,8 +12,8 @@
 	set navigatorId $NavigatorId
 	set navigatorObj $NavigatorObj
 	
-	set color_var [uplevel #0 ${navigatorObj}::my varname color]
-	set label_var [uplevel #0 ${navigatorObj}::my varname label]
+	set color_var [uplevel #0 [list ${navigatorObj}::my varname color]]
+	set label_var [uplevel #0 [list ${navigatorObj}::my varname label]]
 
 	next {*}${args}	
     }

--- a/Tcl/library/oo_Plot_View.tcl
+++ b/Tcl/library/oo_Plot_View.tcl
@@ -103,11 +103,11 @@
 	    set ns [info object namespace $plotModel] 
 	    
 	    foreach state {panX panY zoomX zoomY deltaX deltaY} {
-		set ${state}_var [uplevel #0 ${ns}::my varname $state]
+		set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 		$map set[string toupper $state 0] [set [set ${state}_var]]
 	    }
-	    set background_var [uplevel #0 ${ns}::my varname background]
-	    set swap_var [uplevel #0 ${ns}::my varname swapAxes]
+	    set background_var [uplevel #0 [list ${ns}::my varname background]]
+	    set swap_var [uplevel #0 [list ${ns}::my varname swapAxes]]
 	    $map setSwap [set $swap_var]
 
 	    uplevel #0 [list $canvas configure -background [set $background_var]]

--- a/Tcl/library/oo_PointrangeGlyphVisual.tcl
+++ b/Tcl/library/oo_PointrangeGlyphVisual.tcl
@@ -11,11 +11,11 @@ oo::class create loon::classes::PointrangeGlyphVisual {
 	
 	set ns [info object namespace $glyphObj]
 	
- 	set ymin_var [uplevel #0 ${ns}::my varname ymin]
-	set ymax_var [uplevel #0 ${ns}::my varname ymax]
-	set linewidth_var [uplevel #0 ${ns}::my varname linewidth]
+ 	set ymin_var [uplevel #0 [list ${ns}::my varname ymin]]
+	set ymax_var [uplevel #0 [list ${ns}::my varname ymax]]
+	set linewidth_var [uplevel #0 [list ${ns}::my varname linewidth]]
 	
-	set swap_var [uplevel #0 [info object namespace $map]::my varname swap]
+	set swap_var [uplevel #0 [list [info object namespace $map]::my varname swap]]
 	set y_var $yvar
 		
     }

--- a/Tcl/library/oo_PointsVisual.tcl
+++ b/Tcl/library/oo_PointsVisual.tcl
@@ -9,7 +9,7 @@
 	
 	set ns [info object namespace $Layerobj]	
 	foreach state {color size linecolor linewidth} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_PolygonGlyphVisual.tcl
+++ b/Tcl/library/oo_PolygonGlyphVisual.tcl
@@ -22,8 +22,8 @@ oo::class create loon::classes::PolygonGlyphVisual {
 	my variable glyphObject
 	
 	
-	set id [uplevel #0 $canvas create polygon 0 0 0 0\
-		    -width [lindex [set $linewidth_var] $ind]]
+	set id [uplevel #0 [list $canvas create polygon 0 0 0 0\
+		    -width [lindex [set $linewidth_var] $ind]]]
 	
 	return $id
     }

--- a/Tcl/library/oo_PolygonVisual.tcl
+++ b/Tcl/library/oo_PolygonVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth linecolor} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_PolygonsVisual.tcl
+++ b/Tcl/library/oo_PolygonsVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]
 	foreach state {color linewidth linecolor} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 
 	next $Layerobj {*}$args

--- a/Tcl/library/oo_Rotate3D_Controller.tcl
+++ b/Tcl/library/oo_Rotate3D_Controller.tcl
@@ -14,7 +14,7 @@
         set rotateIndicator -1
 
         set ns [info object namespace $view]
-        set map [set [uplevel #0 ${ns}::my varname map]]
+        set map [set [uplevel #0 [list ${ns}::my varname map]]]
 
         next $view
 

--- a/Tcl/library/oo_Scatterplot3D_View.tcl
+++ b/Tcl/library/oo_Scatterplot3D_View.tcl
@@ -26,7 +26,7 @@
         next $Model
         set ns [info object namespace $plotModel] 
         foreach state {rotate3DX rotate3DY} {
-            set ${state}_var [uplevel #0 ${ns}::my varname $state]
+            set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
             $map set[string toupper $state 0] [set [set ${state}_var]]
         }
         $controller setModel $Model

--- a/Tcl/library/oo_ScatterplotVisual.tcl
+++ b/Tcl/library/oo_ScatterplotVisual.tcl
@@ -27,7 +27,7 @@
 
 	foreach state {n color size selected active xTemp yTemp\
 			   glyph glyphZoomSensitivity foreground} {
-	    set ${state}_var [uplevel #0 ${modelns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${modelns}::my varname $state]]
 	}
 	
 
@@ -523,8 +523,8 @@
 	if {$value} {
 	    my redraw
 	} else {
-	    set tmp [uplevel #0 $canvas create oval 0 0 0 0 -state hidden]
-	    uplevel #0 $canvas lower $tmp $visualid
+	    set tmp [uplevel #0 [list $canvas create oval 0 0 0 0 -state hidden]]
+	    uplevel #0 [list $canvas lower $tmp $visualid]
 	    my clear
 	    set ids $tmp
 	}       	

--- a/Tcl/library/oo_SerialaxesInspectorAnalysis.tcl
+++ b/Tcl/library/oo_SerialaxesInspectorAnalysis.tcl
@@ -296,7 +296,7 @@ oo::class create loon::classes::SerialaxesInspectorAnalysis {
 	set i [lindex [$canvas gettags current] 2]
 	set sel_color [$canvas itemcget "color && inner && $i" -fill]
 	
-	set color [uplevel #0 $activewidget cget -color]
+	set color [uplevel #0 [list $activewidget cget -color]]
 	
 	if {$add} {
 	    set selected [uplevel #0 [list $activewidget cget -selected]]

--- a/Tcl/library/oo_SpiroGlyphVisual.tcl
+++ b/Tcl/library/oo_SpiroGlyphVisual.tcl
@@ -21,8 +21,8 @@ oo::class create loon::classes::SpiroGlyphVisual {
 	my variable glyphObject
 	
 	
-	set id [uplevel #0 $canvas create line 0 0 0 0\
-		    -width [lindex [set $linewidth_var] $ind]]
+	set id [uplevel #0 [list $canvas create line 0 0 0 0\
+		    -width [lindex [set $linewidth_var] $ind]]]
 	
 	return $id
     }

--- a/Tcl/library/oo_SweepBrush_Controller.tcl
+++ b/Tcl/library/oo_SweepBrush_Controller.tcl
@@ -21,7 +21,7 @@
 	set modelLayer ""
 	set bp_modelStateBinding ""
 	
-	set viewMap [set [uplevel #0 [info object namespace $view]::my varname map]]
+	set viewMap [set [uplevel #0 [list [info object namespace $view]::my varname map]]]
 	
 	next $view
 	
@@ -53,7 +53,7 @@
 
 	set ns [info object namespace $Model] 
 	foreach state $sb_soi {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	set modelLayer ""

--- a/Tcl/library/oo_TempMove_Controller.tcl
+++ b/Tcl/library/oo_TempMove_Controller.tcl
@@ -19,7 +19,7 @@
 	    set ${state}_var ""
 	}
 	
-	set viewMap [set [uplevel #0 [info object namespace $view]::my varname map]]
+	set viewMap [set [uplevel #0 [list [info object namespace $view]::my varname map]]]
 	
 	next $view
 	
@@ -32,7 +32,7 @@
 
 	set ns [info object namespace $Model] 
 	foreach state $tm_soi {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Model

--- a/Tcl/library/oo_TextVisual.tcl
+++ b/Tcl/library/oo_TextVisual.tcl
@@ -10,7 +10,7 @@
 
 	set ns [info object namespace $Layerobj]	
 	foreach state {color size text angle anchor justify} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args	

--- a/Tcl/library/oo_TextsVisual.tcl
+++ b/Tcl/library/oo_TextsVisual.tcl
@@ -11,7 +11,7 @@
 	
 	set ns [info object namespace $Layerobj]	
 	foreach state {text anchor justify angle} {
-	    set ${state}_var [uplevel #0 ${ns}::my varname $state]
+	    set ${state}_var [uplevel #0 [list ${ns}::my varname $state]]
 	}
 	
 	next $Layerobj {*}$args	

--- a/Tcl/library/oo_WorldviewMap.tcl
+++ b/Tcl/library/oo_WorldviewMap.tcl
@@ -27,7 +27,7 @@ oo::class create loon::classes::WorldviewMap {
 	    set modelns [info object namespace $model]
 	    
 	    foreach var {panX panY zoomX zoomY} {
-		set ${var}_var [uplevel #0 ${modelns}::my varname $var]
+		set ${var}_var [uplevel #0 [list ${modelns}::my varname $var]]
 	    }
 	}
     }

--- a/Tcl/library/oo_ZoomPan_Controller.tcl
+++ b/Tcl/library/oo_ZoomPan_Controller.tcl
@@ -15,7 +15,7 @@
 	set zoomInFactor 1.1
 	
 	set ns [info object namespace $view]
-	set map [set [uplevel #0 ${ns}::my varname map]]
+	set map [set [uplevel #0 [list ${ns}::my varname map]]]
 
 	next $view
 	

--- a/Tcl/library/x_synchronize.tcl
+++ b/Tcl/library/x_synchronize.tcl
@@ -332,7 +332,7 @@ namespace eval loon {
     proc hasModelLinkedMembers {model} {
 	variable LinkingG2M
 	
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	
 	return [::loon::hasGroupLinkedMembers $group $model]
     }
@@ -343,7 +343,7 @@ namespace eval loon {
 	variable LinkingG2M
 	variable LinkingM2G
 
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	
 	unmapModelFromGroup $model
 	lappend LinkingG2M($group) $model
@@ -408,7 +408,7 @@ namespace eval loon {
     proc numberOfLinkedModels {model} {
 	variable LinkingG2M
 	
-	set group [uplevel #0 ${model}::my cget -linkingGroup]
+	set group [uplevel #0 [list ${model}::my cget -linkingGroup]]
 	set linkedModels $LinkingG2M($group)
 	
 	set i [lsearch -exact $linkedModels $model]


### PR DESCRIPTION
This PR trying to fix several uplevel usages (as described in https://github.com/great-northern-diver/loon/issues/19#issuecomment-528003940).

The last commit trying to improve uplevel evaluation in order to avoid mistaken concat and rewrite of not canonical (or not list) of some single arguments by concatenated evaluation.

A review is still expected (I did not checked all corner cases after the replacement).
May be some `uplevel` calls are obsolete (unneeded) at all, but it is not obvious to me at the moment.

----

Command `uplevel #0 cmd` processing the command `cmd` at top-level, 
but in case of `uplevel #0 [cmd]`, Tcl would firstly execute `cmd` **at current level** and then the result (returned by this command) at top-level.
If command returns empty value (or does not return something at all), `uplevel #0 [cmd]` is comparable with `uplevel #0 {}`, what simply does nothing.

There are 3 "solutions" depending on expected behavior:
- either one should rewrite it as `uplevel #0 [list cmd arg1 ... argN]` to force execution of cmd at top-level;
- or to relocate it to event like `after 0 [list cmd arg1 ... argN]` to execute it retarded (as event, at top-level too)
- or even to remove `uplevel #0 [` at all, so `cmd arg1 ... argN` only, if execution in the current level is allowed (because doing the job all the time).

For example `uplevel #0 [update idletasks]` is the same as `update idletasks` (variant 3), because update always executes pending events at top-level and always returns nothing, so `uplevel #0 {}` is simply called after an update (and doing really nothing there).