### PR TITLE
linking color mapping bugs

### DIFF
--- a/Python/diver/Tcl/library/oo_Configurable_Check.tcl
+++ b/Python/diver/Tcl/library/oo_Configurable_Check.tcl
@@ -14,19 +14,19 @@
     ## add to confDict
     method Check {type var dim args} {
 	if {[dict get $confDict has_$var]} {
-	    
+
 	    set arg_var [dict get $confDict arg_$var]
 	    set n_var [llength $arg_var]
-	    
+
 	    dict set confDict new_$var\
 		[my Check_$type $var $arg_var $dim {*}$args]
-	}	
+	}
     }
-    
+
 
     ## VariableDimensions implements this method too..
     method Check_Dimensionality {var values dim} {
-	
+
 	if {$dim eq "any"} {
 	    ## do nothing
 	} elseif {[string is integer $dim]} {
@@ -38,13 +38,13 @@
 	}
 	return $values
     }
-    
+
     method Check_boolean {var values dim args} {
-	
+
 	if {![::loon::listfns::isBoolean $values]} {
 	    error "Not all elements in -$var are of type boolean."
 	}
-	
+
 	return [my Check_Dimensionality\
 		    $var [::loon::listfns::booleanAsTRUEFALSE $values] $dim]
     }
@@ -55,6 +55,10 @@
 	## remove alpha part from hex6 string
 	set col {}
 	foreach c $values {
+
+	    ## remove unexpected braces
+        set c [regsub -all {\{|\}} $c ""]
+
 	    if {[string index $c 0] eq "#" && [string length $c] eq 9} {
 		lappend col [string range $c 0 6]
 	    } else {
@@ -63,7 +67,6 @@
 	}
 	set values $col
 
-	
 	if {![::loon::listfns::isColor $values]} {
 	    #puts "Warning: Non color arguments for a color state is treated as factor."
 	    set values [::loon::listfns::mapColor $values]
@@ -74,14 +77,14 @@
 
 	set values [my Check_Dimensionality\
 			$var [::loon::listfns::toHexcolor $values] $dim]
-	
+
 	#if {[llength $values] eq 1} {
 	#    set values {*}$values
 	#}
-	
+
 	return $values
     }
-    
+
     method Check_colorOrTransparent {var values dim args} {
 
 
@@ -92,11 +95,11 @@
 		set values [lrepeat [set $dim] ""]
 	    } else {
 		set values ""
-	    }	    
-	    return $values 
+	    }
+	    return $values
 	}
 
-	
+
 	foreach val $values {
 	    if {$val ne ""} {
 		if {![::loon::listfns::isColor $val]} {
@@ -119,29 +122,29 @@
 		incr i
 	    }
 	}
-	
-	set values [my Check_Dimensionality $var $values $dim]	
-	
-	
+
+	set values [my Check_Dimensionality $var $values $dim]
+
+
 	## unwrap color {#...}
 	if {[llength $values] eq 1} {
 	    set values {*}$values
 	}
-	
-	return $values	
+
+	return $values
     }
-    
+
     method Check_positive_double {var values dim args} {
-	
+
 	foreach x $values {
 	    if {![string is double $x] || $x <= 0} {
 		error "Not all elements in -$var are of type positive double (e.g. $x)."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
-    
+
     ## In Tcl everything is a string
     ## Length 1 is not checked
     ## length 2+ must be {{Hello World} {This Is A} {Test}}
@@ -157,35 +160,35 @@
 	}
 	return $values
     }
-    
+
     method Check_double {var values dim args} {
 
 	if {![::loon::listfns::isNumeric $values]} {
 	    error "Not all elements in -$var are of type double."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_factor {var values dim args} {
-	
+
 	set factors [lindex $args 0]
-	
+
 	foreach v $values {
 	    if {$v ni $factors} {
 		error [format "factor -$var level \"$v\" is not valid. Choose from: %s."\
 			   [join $factors ", "]]
 	    }
 	}
-	
-	return [my Check_Dimensionality $var $values $dim]	
+
+	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_integer  {var values dim args} {
 	if {![::loon::listfns::isInteger $values]} {
 	    error "Not all elements in -$var are of type integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -194,20 +197,20 @@
 	if {![::loon::listfns::isPositiveInteger $values]} {
 	    error "Not all elements in -$var are of type positive integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
 
     ## tempcoords are either empty or double of length dim
     method Check_tempcoords {var values dim args} {
-	
+
 	if {[llength $values] eq 0} {
 	    return {}
 	} else {
 	    my Check_double $var $values $dim {*}$args
 	}
-	
+
     }
 
 
@@ -217,14 +220,14 @@
 	    if {![::loon::listfns::isNumeric $vals]} {
 		error "Not all elements in -$var are of type double."
 	    }
-	    
+
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_nested_positive_double {var values dim args} {
-	
+
 	foreach vals $values {
 	    if {![::loon::listfns::isNumeric $vals] || } {
 		error "Not all elements in -$var are of type double."
@@ -233,7 +236,7 @@
 		error "Not all elements in -$var are positive."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -243,7 +246,7 @@
 	if {![::loon::listfns::isImage $values]} {
 	    error "Not all elements in -$var are valid images (e.g. in \[image names\])."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 }

--- a/R/R/get_facets.R
+++ b/R/R/get_facets.R
@@ -35,7 +35,11 @@ get_facets.loon <- function(widget, by, parent = NULL, linkingGroup, inheritLaye
            })
 
     # TODO by is an expression
+    byOriginal <- by
     by <- intersect(by, column_names)
+    if(length(by) == 0) {
+        stop(byOriginal, " is not a valid setting")
+    }
     subtitles <- setNames(lapply(by, function(b) as.character(unique(data[[b]]))), by)
 
     # split data by "by"
@@ -141,33 +145,6 @@ get_facets.loon <- function(widget, by, parent = NULL, linkingGroup, inheritLaye
                                args
                            )
                        )
-                   }
-                   #### THIS IS A HACK!
-                   #### IT IS BECAUSE L_PLOT CANNOT DRAW A SINGEL POINT YET
-                   #### WHEN LOON CAN DO THIS, REMOVE ME!
-                   if(dim(d)[1] == 1) {
-                       if(inherits(widget, "l_plot")) {
-                           # # copy one point to two
-                           # d <- rbind(d,d)
-                           # # fix linkingKey and tag
-                           # N <<- N + 1
-                           # d[2, "linkingKey"] <- paste0(gsub("[0-9]", "", d[1, "linkingKey"]), N)
-                           # d[2, "tag"] <- paste0(gsub("[0-9]", "", d[1, "tag"]), N)
-
-                           args <- c(
-                               ...,
-                               inheritArgs ,
-                               parent = child
-                           )
-                           # remove duplicated names
-                           args <- args[which(!duplicated(names(args)))]
-                           return(
-                               do.call(
-                                   loonFun(widget),
-                                   args
-                               )
-                           )
-                       }
                    }
                    args <- as.list(d)
                    glyph <- args$glyph

--- a/R/inst/tcl/loon/library/oo_Configurable_Check.tcl
+++ b/R/inst/tcl/loon/library/oo_Configurable_Check.tcl
@@ -14,19 +14,19 @@
     ## add to confDict
     method Check {type var dim args} {
 	if {[dict get $confDict has_$var]} {
-	    
+
 	    set arg_var [dict get $confDict arg_$var]
 	    set n_var [llength $arg_var]
-	    
+
 	    dict set confDict new_$var\
 		[my Check_$type $var $arg_var $dim {*}$args]
-	}	
+	}
     }
-    
+
 
     ## VariableDimensions implements this method too..
     method Check_Dimensionality {var values dim} {
-	
+
 	if {$dim eq "any"} {
 	    ## do nothing
 	} elseif {[string is integer $dim]} {
@@ -38,23 +38,26 @@
 	}
 	return $values
     }
-    
+
     method Check_boolean {var values dim args} {
-	
+
 	if {![::loon::listfns::isBoolean $values]} {
 	    error "Not all elements in -$var are of type boolean."
 	}
-	
+
 	return [my Check_Dimensionality\
 		    $var [::loon::listfns::booleanAsTRUEFALSE $values] $dim]
     }
 
     method Check_color {var values dim args} {
 
-
 	## remove alpha part from hex6 string
 	set col {}
 	foreach c $values {
+
+	    ## remove unexpected braces
+        set c [regsub -all {\{|\}} $c ""]
+
 	    if {[string index $c 0] eq "#" && [string length $c] eq 9} {
 		lappend col [string range $c 0 6]
 	    } else {
@@ -63,7 +66,6 @@
 	}
 	set values $col
 
-	
 	if {![::loon::listfns::isColor $values]} {
 	    #puts "Warning: Non color arguments for a color state is treated as factor."
 	    set values [::loon::listfns::mapColor $values]
@@ -74,14 +76,14 @@
 
 	set values [my Check_Dimensionality\
 			$var [::loon::listfns::toHexcolor $values] $dim]
-	
+
 	#if {[llength $values] eq 1} {
 	#    set values {*}$values
 	#}
-	
+
 	return $values
     }
-    
+
     method Check_colorOrTransparent {var values dim args} {
 
 
@@ -92,11 +94,11 @@
 		set values [lrepeat [set $dim] ""]
 	    } else {
 		set values ""
-	    }	    
-	    return $values 
+	    }
+	    return $values
 	}
 
-	
+
 	foreach val $values {
 	    if {$val ne ""} {
 		if {![::loon::listfns::isColor $val]} {
@@ -119,29 +121,29 @@
 		incr i
 	    }
 	}
-	
-	set values [my Check_Dimensionality $var $values $dim]	
-	
-	
+
+	set values [my Check_Dimensionality $var $values $dim]
+
+
 	## unwrap color {#...}
 	if {[llength $values] eq 1} {
 	    set values {*}$values
 	}
-	
-	return $values	
+
+	return $values
     }
-    
+
     method Check_positive_double {var values dim args} {
-	
+
 	foreach x $values {
 	    if {![string is double $x] || $x <= 0} {
 		error "Not all elements in -$var are of type positive double (e.g. $x)."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
-    
+
     ## In Tcl everything is a string
     ## Length 1 is not checked
     ## length 2+ must be {{Hello World} {This Is A} {Test}}
@@ -157,35 +159,35 @@
 	}
 	return $values
     }
-    
+
     method Check_double {var values dim args} {
 
 	if {![::loon::listfns::isNumeric $values]} {
 	    error "Not all elements in -$var are of type double."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_factor {var values dim args} {
-	
+
 	set factors [lindex $args 0]
-	
+
 	foreach v $values {
 	    if {$v ni $factors} {
 		error [format "factor -$var level \"$v\" is not valid. Choose from: %s."\
 			   [join $factors ", "]]
 	    }
 	}
-	
-	return [my Check_Dimensionality $var $values $dim]	
+
+	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_integer  {var values dim args} {
 	if {![::loon::listfns::isInteger $values]} {
 	    error "Not all elements in -$var are of type integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -194,20 +196,20 @@
 	if {![::loon::listfns::isPositiveInteger $values]} {
 	    error "Not all elements in -$var are of type positive integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
 
     ## tempcoords are either empty or double of length dim
     method Check_tempcoords {var values dim args} {
-	
+
 	if {[llength $values] eq 0} {
 	    return {}
 	} else {
 	    my Check_double $var $values $dim {*}$args
 	}
-	
+
     }
 
 
@@ -217,14 +219,14 @@
 	    if {![::loon::listfns::isNumeric $vals]} {
 		error "Not all elements in -$var are of type double."
 	    }
-	    
+
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_nested_positive_double {var values dim args} {
-	
+
 	foreach vals $values {
 	    if {![::loon::listfns::isNumeric $vals] || } {
 		error "Not all elements in -$var are of type double."
@@ -233,7 +235,7 @@
 		error "Not all elements in -$var are positive."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -243,7 +245,7 @@
 	if {![::loon::listfns::isImage $values]} {
 	    error "Not all elements in -$var are valid images (e.g. in \[image names\])."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 }

--- a/Tcl/library/oo_Configurable_Check.tcl
+++ b/Tcl/library/oo_Configurable_Check.tcl
@@ -14,19 +14,19 @@
     ## add to confDict
     method Check {type var dim args} {
 	if {[dict get $confDict has_$var]} {
-	    
+
 	    set arg_var [dict get $confDict arg_$var]
 	    set n_var [llength $arg_var]
-	    
+
 	    dict set confDict new_$var\
 		[my Check_$type $var $arg_var $dim {*}$args]
-	}	
+	}
     }
-    
+
 
     ## VariableDimensions implements this method too..
     method Check_Dimensionality {var values dim} {
-	
+
 	if {$dim eq "any"} {
 	    ## do nothing
 	} elseif {[string is integer $dim]} {
@@ -38,13 +38,13 @@
 	}
 	return $values
     }
-    
+
     method Check_boolean {var values dim args} {
-	
+
 	if {![::loon::listfns::isBoolean $values]} {
 	    error "Not all elements in -$var are of type boolean."
 	}
-	
+
 	return [my Check_Dimensionality\
 		    $var [::loon::listfns::booleanAsTRUEFALSE $values] $dim]
     }
@@ -55,6 +55,10 @@
 	## remove alpha part from hex6 string
 	set col {}
 	foreach c $values {
+
+	    ## remove unexpected braces
+        set c [regsub -all {\{|\}} $c ""]
+
 	    if {[string index $c 0] eq "#" && [string length $c] eq 9} {
 		lappend col [string range $c 0 6]
 	    } else {
@@ -63,7 +67,6 @@
 	}
 	set values $col
 
-	
 	if {![::loon::listfns::isColor $values]} {
 	    #puts "Warning: Non color arguments for a color state is treated as factor."
 	    set values [::loon::listfns::mapColor $values]
@@ -74,14 +77,14 @@
 
 	set values [my Check_Dimensionality\
 			$var [::loon::listfns::toHexcolor $values] $dim]
-	
+
 	#if {[llength $values] eq 1} {
 	#    set values {*}$values
 	#}
-	
+
 	return $values
     }
-    
+
     method Check_colorOrTransparent {var values dim args} {
 
 
@@ -92,11 +95,11 @@
 		set values [lrepeat [set $dim] ""]
 	    } else {
 		set values ""
-	    }	    
-	    return $values 
+	    }
+	    return $values
 	}
 
-	
+
 	foreach val $values {
 	    if {$val ne ""} {
 		if {![::loon::listfns::isColor $val]} {
@@ -119,29 +122,29 @@
 		incr i
 	    }
 	}
-	
-	set values [my Check_Dimensionality $var $values $dim]	
-	
-	
+
+	set values [my Check_Dimensionality $var $values $dim]
+
+
 	## unwrap color {#...}
 	if {[llength $values] eq 1} {
 	    set values {*}$values
 	}
-	
-	return $values	
+
+	return $values
     }
-    
+
     method Check_positive_double {var values dim args} {
-	
+
 	foreach x $values {
 	    if {![string is double $x] || $x <= 0} {
 		error "Not all elements in -$var are of type positive double (e.g. $x)."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
-    
+
     ## In Tcl everything is a string
     ## Length 1 is not checked
     ## length 2+ must be {{Hello World} {This Is A} {Test}}
@@ -157,35 +160,35 @@
 	}
 	return $values
     }
-    
+
     method Check_double {var values dim args} {
 
 	if {![::loon::listfns::isNumeric $values]} {
 	    error "Not all elements in -$var are of type double."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_factor {var values dim args} {
-	
+
 	set factors [lindex $args 0]
-	
+
 	foreach v $values {
 	    if {$v ni $factors} {
 		error [format "factor -$var level \"$v\" is not valid. Choose from: %s."\
 			   [join $factors ", "]]
 	    }
 	}
-	
-	return [my Check_Dimensionality $var $values $dim]	
+
+	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_integer  {var values dim args} {
 	if {![::loon::listfns::isInteger $values]} {
 	    error "Not all elements in -$var are of type integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -194,20 +197,20 @@
 	if {![::loon::listfns::isPositiveInteger $values]} {
 	    error "Not all elements in -$var are of type positive integer."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
 
     ## tempcoords are either empty or double of length dim
     method Check_tempcoords {var values dim args} {
-	
+
 	if {[llength $values] eq 0} {
 	    return {}
 	} else {
 	    my Check_double $var $values $dim {*}$args
 	}
-	
+
     }
 
 
@@ -217,14 +220,14 @@
 	    if {![::loon::listfns::isNumeric $vals]} {
 		error "Not all elements in -$var are of type double."
 	    }
-	    
+
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
     method Check_nested_positive_double {var values dim args} {
-	
+
 	foreach vals $values {
 	    if {![::loon::listfns::isNumeric $vals] || } {
 		error "Not all elements in -$var are of type double."
@@ -233,7 +236,7 @@
 		error "Not all elements in -$var are positive."
 	    }
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 
@@ -243,7 +246,7 @@
 	if {![::loon::listfns::isImage $values]} {
 	    error "Not all elements in -$var are valid images (e.g. in \[image names\])."
 	}
-	
+
 	return [my Check_Dimensionality $var $values $dim]
     }
 }

--- a/Tcl/library/oo_Configurable_Check.tcl
+++ b/Tcl/library/oo_Configurable_Check.tcl
@@ -67,12 +67,7 @@
 	}
 	set values $col
 
-<<<<<<< HEAD
-=======
-    ## remove unexpected braces
-    set values [regsub -all {\{|\}} $values ""]
 
->>>>>>> 1ae151c310a4036babf8c6ace8f515ddd94ec322
 	if {![::loon::listfns::isColor $values]} {
 	    #puts "Warning: Non color arguments for a color state is treated as factor."
 	    set values [::loon::listfns::mapColor $values]


### PR DESCRIPTION
Bug: if the lengths of the observations in different plots vary, the linking color may fail to match. 

The problem is in `loon` `tcl`. It will run a function called `Check_color`  automatically. In `tcl` , the first object in vector is in braces. Say a `tcl` vector (or list to be more precise) {a, b, c}, the output is like {a}, b, c. If the lengths of the observations in different plots vary, the first object may have double braces (why this happen? Sorry, I don't know either...), which is like {{a}}, b, c. So, when we throw this vector into function `isColor` , it fails to recognize because {red} can be considered as color  (the `tcl` will throw the first {} by default)  but {{red}} is not any more. If the `isColor`  fails, the vector will be mapped to default loon color, that's why no matter how we change the color, the first color is always **gray60** and the second color is always **lightblue.** 