### PR TITLE
`loonGrob.l_serialaxes` bug:

### DIFF
--- a/R/R/extractBinInfo.R
+++ b/R/R/extractBinInfo.R
@@ -67,8 +67,6 @@ getBinData <- function(widget) {
 
 #' @rdname Extract-Bin-Info
 #'
-#' @inheritParams Extract-Bin-Info
-#'
 #' @details \code{l_getBinIds} returns the ids of each bin
 #'
 #' @export
@@ -91,8 +89,6 @@ l_getBinIds <- function(widget) {
 }
 
 #' @rdname Extract-Bin-Info
-#'
-#' @inheritParams Extract-Bin-Info
 #'
 #' @details \code{l_breaks} returns the range (breaks) of each bin
 #'

--- a/R/R/l_binCut.R
+++ b/R/R/l_binCut.R
@@ -1,6 +1,5 @@
 #' @rdname Extract-Bin-Info
 #'
-#' @inheritParams Extract-Bin-Info
 #' @param labels Labels for the levels of the resulting category.
 #' By default, labels are constructed using "(a,b]" interval notation.
 #' If labels = FALSE, simple integer codes are returned instead of a factor.

--- a/R/R/loonGrob_l_serialaxes.R
+++ b/R/R/loonGrob_l_serialaxes.R
@@ -416,7 +416,13 @@ get_scaledData <- function(data,
     if(missing(data) || is.null(data) || is.null(displayOrder)) return(NULL)
 
     if(!is.null(sequence)) {
-        col_name <- colnames(data)
+
+        col_name <- make.names(colnames(data))
+        # sequence names may involve invalid chars
+        # such as `(`, `)`, ` ` space, etc.
+        # call function `make.names` can remove all these chars to match data column names
+        sequence <- make.names(sequence)
+
         if(!all(sequence %in% col_name)) {
             warning("unknown variable names in sequence")
             sequence <- intersect(sequence, col_name)


### PR DESCRIPTION
column names of a data frame involve illegal chars, such as `(`, `)`, `.` , etc.