### PR TITLE
Test and grob meaningful names

### DIFF
--- a/R/R/l_binCut.R
+++ b/R/R/l_binCut.R
@@ -31,6 +31,7 @@
 #' @export
 #'
 #' @examples
+#' if(interactive()) {
 #' h <- l_hist(iris)
 #' h["active"] <- iris$Species != "setosa"
 #' binCut <- l_binCut(h)
@@ -44,6 +45,8 @@
 #' }
 #' h['color'] <- l_binCut(h, labels = gg_color_hue(nBins), inactive = "firebrick")
 #' h["active"] <- TRUE
+#' }
+#'
 l_binCut <- function(widget, labels, digits = 2, inactive) {
 
     stopifnot({inherits(widget, "l_hist")})

--- a/R/R/loonGrob_l_compound.R
+++ b/R/R/loonGrob_l_compound.R
@@ -35,7 +35,7 @@ loonGrob.l_compound <- function(target, name = NULL, gp = NULL, vp = NULL){
     arrangeGrob.args <- switch(loonGrob_layoutType(target),
                                locations = {
                                    plots <- l_getPlots(target)
-                                   grobs <- lapply(plots, function(w){loonGrob(w)})
+                                   grobs <- setNames(lapply(plots, function(p){loonGrob(p)}), as.character(plots))
                                    locations <- l_getLocations(target)
                                    is_locationNames <- names(locations) %in% c("ncol", "nrow",
                                                                                "layout_matrix",

--- a/R/R/loonGrob_l_pairs.R
+++ b/R/R/loonGrob_l_pairs.R
@@ -13,7 +13,7 @@ l_get_arrangeGrobArgs.l_pairs <- function(target) {
     scatterplots <- histograms <- serialAxes <- list()
     plotNames <- names(target)
 
-    for(i in 1:nPlots) {
+    for(i in seq(nPlots)) {
         if(inherits(target[[i]], "l_plot")) {
             nScatterplots <- nScatterplots + 1
             scatterplots[[nScatterplots]] <- target[[i]]
@@ -44,7 +44,7 @@ l_get_arrangeGrobArgs.l_pairs <- function(target) {
     } else showTexts <- TRUE
 
     scatter_hist <- c(scatterplots, histograms)
-    scatter_histGrobs <- lapply(1:(nScatterplots + nHistograms),
+    scatter_histGrobs <- lapply(seq(nScatterplots + nHistograms),
                                 function(i){
                                     pi <- scatter_hist[[i]]
                                     pi['minimumMargins'] <- rep(2,4)
@@ -81,7 +81,7 @@ l_get_arrangeGrobArgs.l_pairs <- function(target) {
             )
         )
 
-        textGrobs <- lapply(1:length(texts),
+        textGrobs <- lapply(seq(length(texts)),
                             function(i) {
                                 textGrob(texts[i], gp = gpar(fontsize = 9), name = paste("text", i))
                             }
@@ -109,10 +109,22 @@ l_get_arrangeGrobArgs.l_pairs <- function(target) {
         locations$layout_matrix <- layout_matrix
     }
 
+    if(showTexts) {
+        grobs <- setNames(c(scatter_histGrobs, serialAxesGrob, textGrobs),
+                          c(as.character(scatter_hist), as.character(serialAxes),
+                            texts))
+
+    } else {
+        grobs <- setNames(c(scatter_histGrobs, serialAxesGrob),
+                          c(as.character(scatter_hist), as.character(serialAxes)))
+    }
+
+
+
     c(
         locations,
         list(
-            grobs = c(scatter_histGrobs, serialAxesGrob, if(showTexts) textGrobs else NULL),
+            grobs = grobs,
             name = "l_pairs"
         )
     )
@@ -125,7 +137,7 @@ l_createCompoundGrob.l_pairs <- function(target, arrangeGrob.args){
         rectGrob(gp  = gpar(fill = backgroundCol, col = NA),
                  name = "bounding box"),
         do.call(gridExtra::arrangeGrob,  arrangeGrob.args),
-        name = "l_pairs"
+        name = "pairs"
     )
 }
 

--- a/R/man/l_binCut.Rd
+++ b/R/man/l_binCut.Rd
@@ -36,6 +36,7 @@ The value of \code{active} denotes the bin name for the inactive cases.
 \code{x} according to which interval they fall (if active). It is modelled on \code{\link{cut}} in \code{base} package.
 }
 \examples{
+if(interactive()) {
 h <- l_hist(iris)
 h["active"] <- iris$Species != "setosa"
 binCut <- l_binCut(h)
@@ -49,6 +50,8 @@ gg_color_hue <- function(n) {
 }
 h['color'] <- l_binCut(h, labels = gg_color_hue(nBins), inactive = "firebrick")
 h["active"] <- TRUE
+}
+
 }
 \seealso{
 \code{\link{l_getBinData}}, \code{\link{l_getBinIds}}, \code{\link{l_breaks}}

--- a/R/tests/testthat/test_facets.R
+++ b/R/tests/testthat/test_facets.R
@@ -280,10 +280,13 @@ test_that("test formula by", {
                 by = size ~ color,
                 on = on)
 
-    expect_equal(p[[1]]['color'], "#000080800000") # green
+    # avoid hex code in tests
+    # it is because, in solaris X64 system, the 12 digit hex code is slightly different from that in
+    # windows and mac
+    # expect_equal(p[[1]]['color'], "#000080800000") # green
     expect_equal(p[[1]]['size'], 25)
 
-    expect_equal(p[[2]]['color'], c("#000080800000", "#000080800000")) # green
+    # expect_equal(p[[2]]['color'], c("#000080800000", "#000080800000")) # green
     expect_equal(p[[2]]['size'], c(50, 50))
 
 
@@ -297,12 +300,12 @@ test_that("test formula by", {
                 color = c(rep("red", 3), rep("green", 3)),
                 by = size ~ color + glyph)
 
-    expect_equal(p[[1]]['color'], "#000080800000") # green
+    # expect_equal(p[[1]]['color'], "#000080800000") # green
     expect_equal(p[[1]]['size'], 25)
     expect_equal(p[[1]]['glyph'], "ccircle")
 
 
-    expect_equal(p[[8]]['color'], "#FFFF00000000") # red
+    # expect_equal(p[[8]]['color'], "#FFFF00000000") # red
     expect_equal(p[[8]]['size'], 50)
     expect_equal(p[[8]]['glyph'], "ocircle")
 
@@ -317,18 +320,18 @@ test_that("test formula by", {
     f <- l_facet(p, by = color ~ size, layout = "wrap")
 
     expect_equal(f[[1]]['size'], 25)
-    expect_equal(f[[1]]['color'], "#000080800000") # green
+    # expect_equal(f[[1]]['color'], "#000080800000") # green
 
     expect_equal(f[[2]]['size'], 25)
-    expect_equal(f[[2]]['color'], "#FFFF00000000") # red
+    # expect_equal(f[[2]]['color'], "#FFFF00000000") # red
 
     f <- l_facet(p, by = color ~ size)
 
     expect_equal(f[[1]]['size'], 25)
-    expect_equal(f[[1]]['color'], "#000080800000") # green
+    # expect_equal(f[[1]]['color'], "#000080800000") # green
 
     expect_equal(f[[2]]['size'], 25)
-    expect_equal(f[[2]]['color'], "#FFFF00000000") # red
+    # expect_equal(f[[2]]['color'], "#FFFF00000000") # red
 
 
     on <- data.frame(Factor1 = c(rep("A", 3), rep("B", 3)),

--- a/R/tests/testthat/test_facets.R
+++ b/R/tests/testthat/test_facets.R
@@ -283,10 +283,10 @@ test_that("test formula by", {
     # avoid hex code in tests
     # it is because, in solaris X64 system, the 12 digit hex code is slightly different from that in
     # windows and mac
-    # expect_equal(p[[1]]['color'], "#000080800000") # green
+    expect_equal(p[[1]]['color'], l_hexcolor("green")) # green
     expect_equal(p[[1]]['size'], 25)
 
-    # expect_equal(p[[2]]['color'], c("#000080800000", "#000080800000")) # green
+    expect_equal(p[[2]]['color'], c(l_hexcolor("green"), l_hexcolor("green"))) # green
     expect_equal(p[[2]]['size'], c(50, 50))
 
 
@@ -300,12 +300,12 @@ test_that("test formula by", {
                 color = c(rep("red", 3), rep("green", 3)),
                 by = size ~ color + glyph)
 
-    # expect_equal(p[[1]]['color'], "#000080800000") # green
+    expect_equal(p[[1]]['color'], l_hexcolor("green")) # green
     expect_equal(p[[1]]['size'], 25)
     expect_equal(p[[1]]['glyph'], "ccircle")
 
 
-    # expect_equal(p[[8]]['color'], "#FFFF00000000") # red
+    expect_equal(p[[8]]['color'], l_hexcolor("red")) # red
     expect_equal(p[[8]]['size'], 50)
     expect_equal(p[[8]]['glyph'], "ocircle")
 
@@ -320,18 +320,18 @@ test_that("test formula by", {
     f <- l_facet(p, by = color ~ size, layout = "wrap")
 
     expect_equal(f[[1]]['size'], 25)
-    # expect_equal(f[[1]]['color'], "#000080800000") # green
+    expect_equal(f[[1]]['color'], l_hexcolor("green")) # green
 
     expect_equal(f[[2]]['size'], 25)
-    # expect_equal(f[[2]]['color'], "#FFFF00000000") # red
+    expect_equal(f[[2]]['color'], l_hexcolor("red")) # red
 
     f <- l_facet(p, by = color ~ size)
 
     expect_equal(f[[1]]['size'], 25)
-    # expect_equal(f[[1]]['color'], "#000080800000") # green
+    expect_equal(f[[1]]['color'], l_hexcolor("green")) # green
 
     expect_equal(f[[2]]['size'], 25)
-    # expect_equal(f[[2]]['color'], "#FFFF00000000") # red
+    expect_equal(f[[2]]['color'], l_hexcolor("red")) # red
 
 
     on <- data.frame(Factor1 = c(rep("A", 3), rep("B", 3)),

--- a/R/tests/testthat/test_linking.R
+++ b/R/tests/testthat/test_linking.R
@@ -1,12 +1,13 @@
 
 context("test_linking")
 
-test_that("linking on size and color works", {
+test_that("linking on size and selected works", {
 
     n <- nrow(iris)
+    selected <- sample(c(T, F), size = 150, replace = TRUE)
     p1 <- l_plot(iris,
-                 color = iris$Species,
                  size = sample(c(2, 4, 8), n, replace = TRUE),
+                 selected = selected,
                  linkingGroup = "iris")
     p2 <- l_plot(iris, linkingGroup = "iris")
     p3 <- l_plot3D(iris$Sepal.Length, iris$Sepal.Width, iris$Petal.Length,
@@ -14,37 +15,37 @@ test_that("linking on size and color works", {
     h <- l_hist(iris, linkingGroup = "iris")
     sa <- l_serialaxes(iris, linkingGroup = "iris")
 
-    color <- p1['color']
-    expect_equal(p2['color'], color)
-    expect_equal(p3['color'], color)
-    expect_equal(h['color'], color)
-    expect_equal(sa['color'], color)
+    selected <- p1['selected']
+    expect_equal(p2['selected'], selected)
+    expect_equal(p3['selected'], selected)
+    expect_equal(h['selected'], selected)
+    expect_equal(sa['selected'], selected)
 
     size <- p1['size']
     expect_equal(p2['size'], size)
     expect_equal(p3['size'], size)
 
-    p3["color"] <- sample(c("red", "green", "blue", "magenta"), n, replace = TRUE)
+    p3["selected"] <- sample(c(T, F), size = 150, replace = TRUE)
 
-    expect_equal(p1['color'], p3['color'])
-    expect_equal(p2['color'], p3['color'])
-    expect_equal(h['color'], p3['color'])
-    expect_equal(sa['color'], p3['color'])
+    expect_equal(p1['selected'], p3['selected'])
+    expect_equal(p2['selected'], p3['selected'])
+    expect_equal(h['selected'], p3['selected'])
+    expect_equal(sa['selected'], p3['selected'])
 
 
-    h["color"] <- sample(c("red", "green", "blue", "magenta"), n, replace = TRUE)
+    h["selected"] <- sample(c(T, F), size = 150, replace = TRUE)
 
-    expect_equal(p1['color'], h['color'])
-    expect_equal(p2['color'], h['color'])
-    expect_equal(p3['color'], h['color'])
-    expect_equal(sa['color'], h['color'])
+    expect_equal(p1['selected'], h['selected'])
+    expect_equal(p2['selected'], h['selected'])
+    expect_equal(p3['selected'], h['selected'])
+    expect_equal(sa['selected'], h['selected'])
 
-    sa["color"] <- sample(c("red", "green", "blue", "magenta"), n, replace = TRUE)
+    sa["selected"] <- sample(c(T, F), size = 150, replace = TRUE)
 
-    expect_equal(p1['color'], sa['color'])
-    expect_equal(p2['color'], sa['color'])
-    expect_equal(p3['color'], sa['color'])
-    expect_equal(h['color'], sa['color'])
+    expect_equal(p1['selected'], sa['selected'])
+    expect_equal(p2['selected'], sa['selected'])
+    expect_equal(p3['selected'], sa['selected'])
+    expect_equal(h['selected'], sa['selected'])
 
     p2["size"] <-  sample(c(2, 4, 8), n, replace = TRUE)
     expect_equal(p1['size'], p2['size'])

--- a/R/tests/testthat/test_sync.R
+++ b/R/tests/testthat/test_sync.R
@@ -2,9 +2,8 @@ context("test_sync")
 
 test_that("test pull", {
 
-    p <- l_plot(as.character(iris$Species), color = "#FF0000") # red
-    col <- hex12tohex6(unique(p['color']))
-    # expect_equal(col, "#FF0000")
+    p <- l_plot(as.character(iris$Species), color = "red") # red
+    expect_equal(unique(p['color']), l_hexcolor("red"))
 
     l_configure(p, linkingGroup = "iris", sync = "push")
 
@@ -12,15 +11,14 @@ test_that("test pull", {
     expect_warning(
         q <- l_plot(iris$Petal.Width,
                     linkingGroup = "iris",
-                    color = "#008000", # green
+                    color = "green", # green
                     size = 6,
                     selected = TRUE,
                     active = sample(c(T, F), size = 150, replace = TRUE),
                     glyph = "triangle")
     )
     # color, size, selected and active are linked
-    # col <- hex12tohex6(unique(q['color']))
-    # expect_equal(col, "#FF0000")
+    expect_equal(unique(q['color']), l_hexcolor("red"))
 
     size <- unique(q['size'])
     expect_equal(as.character(size), l_getOption("size"))
@@ -38,26 +36,24 @@ test_that("test pull", {
     ################## histogram
     expect_warning(h <- l_hist(iris$Petal.Length,
                                linkingGroup = "iris",
-                               color = "#FF0000", # red
+                               color = "red", # red
                                selected = TRUE))
 
     selected <- all(!h['selected'])
     expect_true(selected)
 
-    # col <- hex12tohex6(unique(h['color']))
-    # expect_equal(col, "#FF0000")
+    expect_equal(unique(h['color']), l_hexcolor("red"))
 
     ################## serialaxes
     expect_warning(s <- l_serialaxes(iris[, -5],
                                      linkingGroup = "iris",
-                                     color = "#008000", # green
+                                     color = "green", # green
                                      active = FALSE))
 
     active <- all(s['active'])
     expect_true(active)
 
-    # col <- hex12tohex6(unique(s['color']))
-    # expect_equal(col, "#FF0000")
+    expect_equal(unique(s['color']), l_hexcolor("red"))
 
     ################## graph
     pp <- l_plot(1:4, linkingGroup = "foo", sync = "pull",
@@ -90,19 +86,18 @@ test_that("test pull", {
                           showHistograms = TRUE,
                           showSerialAxes = TRUE,
                           linkingGroup = "iris",
-                          color = "#008000") # green
+                          color = "green") # green
     )
-    # col <- hex12tohex6(unique(unlist(ppairs['color'])))
-    # expect_equal(col, "#FF0000")
+
+    expect_equal(unique(unlist(ppairs['color'])), l_hexcolor("red"))
 
     ### ts
     expect_warning(
         pts <- l_plot(decompose(co2),
                       linkingGroup = "iris",
-                      color = "#008000") # green
+                      color = "green") # green
     )
-    # col <- hex12tohex6(unique(pts[[1]]['color'][1:150]))
-    # expect_equal(col, "#FF0000")
+    expect_equal(unique(pts[[1]]['color'][1:150]), l_hexcolor("red"))
 })
 
 
@@ -120,7 +115,7 @@ test_that("test push", {
                 color = "black",
                 linkingGroup = "iris1", sync = "push")
     # only the color is modified
-    # expect_true(all(q[[1]]['color'] == "#000000000000"))
+    expect_true(all(q[[1]]['color'] == l_hexcolor("black")))
     # the size of each plot should be the same with the random sample
     expect_true(all(q[[1]]['size'] == size[1:50]))
     expect_true(all(q[[2]]['size'] == size[51:100]))
@@ -147,7 +142,7 @@ test_that("test push", {
 
     expect_true(all(p['size'] == size))
     expect_false(all(p['selected']))
-    # expect_true(all(as_hex6color(p['color']) == as_hex6color(color)))
+    expect_true(all(p['color'] == l_hexcolor(color)))
 
     s1 <- l_serialaxes(iris, by = iris$Species,
                        linkingGroup = "iris1",
@@ -155,14 +150,14 @@ test_that("test push", {
                        sync = "push")
 
 
-    # expect_true(all(s['color'] == "#000000000000"))
+    expect_true(all(s['color'] == l_hexcolor("black")))
     expect_true(all(s['linewidth'] == size))
 
     pair <- l_pairs(iris[, 1:3], linkingGroup = "iris1", sync = "push",
                     color = "red")
 
     expect_true(all(s['linewidth'] == size))
-    # expect_true(all(s['color'] == "#FFFF00000000"))
+    expect_true(all(s['color'] == l_hexcolor("red")))
 
     # push test
     # the states of the new plot are the default
@@ -178,7 +173,7 @@ test_that("test push", {
                  sync = "push",
                  selected = FALSE)
 
-    # expect_true(all(p1['color'] == "#999999999999"))
+    expect_true(all(p1['color'] == l_hexcolor("gray60")))
     expect_true(all(p1['size'] == 4))
     expect_false(any(p1['selected']))
 })

--- a/R/tests/testthat/test_sync.R
+++ b/R/tests/testthat/test_sync.R
@@ -4,7 +4,7 @@ test_that("test pull", {
 
     p <- l_plot(as.character(iris$Species), color = "#FF0000") # red
     col <- hex12tohex6(unique(p['color']))
-    expect_equal(col, "#FF0000")
+    # expect_equal(col, "#FF0000")
 
     l_configure(p, linkingGroup = "iris", sync = "push")
 
@@ -19,8 +19,8 @@ test_that("test pull", {
                     glyph = "triangle")
     )
     # color, size, selected and active are linked
-    col <- hex12tohex6(unique(q['color']))
-    expect_equal(col, "#FF0000")
+    # col <- hex12tohex6(unique(q['color']))
+    # expect_equal(col, "#FF0000")
 
     size <- unique(q['size'])
     expect_equal(as.character(size), l_getOption("size"))
@@ -44,8 +44,8 @@ test_that("test pull", {
     selected <- all(!h['selected'])
     expect_true(selected)
 
-    col <- hex12tohex6(unique(h['color']))
-    expect_equal(col, "#FF0000")
+    # col <- hex12tohex6(unique(h['color']))
+    # expect_equal(col, "#FF0000")
 
     ################## serialaxes
     expect_warning(s <- l_serialaxes(iris[, -5],
@@ -56,8 +56,8 @@ test_that("test pull", {
     active <- all(s['active'])
     expect_true(active)
 
-    col <- hex12tohex6(unique(s['color']))
-    expect_equal(col, "#FF0000")
+    # col <- hex12tohex6(unique(s['color']))
+    # expect_equal(col, "#FF0000")
 
     ################## graph
     pp <- l_plot(1:4, linkingGroup = "foo", sync = "pull",
@@ -92,8 +92,8 @@ test_that("test pull", {
                           linkingGroup = "iris",
                           color = "#008000") # green
     )
-    col <- hex12tohex6(unique(unlist(ppairs['color'])))
-    expect_equal(col, "#FF0000")
+    # col <- hex12tohex6(unique(unlist(ppairs['color'])))
+    # expect_equal(col, "#FF0000")
 
     ### ts
     expect_warning(
@@ -101,8 +101,8 @@ test_that("test pull", {
                       linkingGroup = "iris",
                       color = "#008000") # green
     )
-    col <- hex12tohex6(unique(pts[[1]]['color'][1:150]))
-    expect_equal(col, "#FF0000")
+    # col <- hex12tohex6(unique(pts[[1]]['color'][1:150]))
+    # expect_equal(col, "#FF0000")
 })
 
 
@@ -120,7 +120,7 @@ test_that("test push", {
                 color = "black",
                 linkingGroup = "iris1", sync = "push")
     # only the color is modified
-    expect_true(all(q[[1]]['color'] == "#000000000000"))
+    # expect_true(all(q[[1]]['color'] == "#000000000000"))
     # the size of each plot should be the same with the random sample
     expect_true(all(q[[1]]['size'] == size[1:50]))
     expect_true(all(q[[2]]['size'] == size[51:100]))
@@ -147,7 +147,7 @@ test_that("test push", {
 
     expect_true(all(p['size'] == size))
     expect_false(all(p['selected']))
-    expect_true(all(as_hex6color(p['color']) == as_hex6color(color)))
+    # expect_true(all(as_hex6color(p['color']) == as_hex6color(color)))
 
     s1 <- l_serialaxes(iris, by = iris$Species,
                        linkingGroup = "iris1",
@@ -155,14 +155,14 @@ test_that("test push", {
                        sync = "push")
 
 
-    expect_true(all(s['color'] == "#000000000000"))
+    # expect_true(all(s['color'] == "#000000000000"))
     expect_true(all(s['linewidth'] == size))
 
     pair <- l_pairs(iris[, 1:3], linkingGroup = "iris1", sync = "push",
                     color = "red")
 
     expect_true(all(s['linewidth'] == size))
-    expect_true(all(s['color'] == "#FFFF00000000"))
+    # expect_true(all(s['color'] == "#FFFF00000000"))
 
     # push test
     # the states of the new plot are the default
@@ -178,7 +178,7 @@ test_that("test push", {
                  sync = "push",
                  selected = FALSE)
 
-    expect_true(all(p1['color'] == "#999999999999"))
+    # expect_true(all(p1['color'] == "#999999999999"))
     expect_true(all(p1['size'] == 4))
     expect_false(any(p1['selected']))
 })


### PR DESCRIPTION
1. remove 12 digits hex code test in testthat. 
    The main reason is that in solaris, the 12 digits code is slightly different from that in windows and mac.
2. give meaningful names to compound object. 