### PR TITLE
Two issues

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: loon
 Type: Package
 Title: Interactive Statistical Data Visualization
-Version: 1.3.5
+Version: 1.3.6
 Date: 2021-03-15
 Authors@R: c(person(given = "Adrian", family = "Waddell", 
                     email = "adrian@waddell.ch", 

--- a/R/R/l_isLoonWidget.R
+++ b/R/R/l_isLoonWidget.R
@@ -1,22 +1,19 @@
 
 #' @title Check if a widget path is a valid loon widget
-#'   
+#'
 #' @description This function can be useful to check whether a loon widget is
 #'   has been closed by the user.
-#'   
+#'
 #' @template param_widget
-#'   
-#' @return boolean, TRUE if the argument is a valid loon widget path, FALSE 
+#'
+#' @return boolean, TRUE if the argument is a valid loon widget path, FALSE
 #'   otherwise
-#'   
+#'
 #' @export
 l_isLoonWidget <- function(widget) {
-    if(is.list(widget)){
-        FALSE
-    }else{
-        isLoon <- as.logical(as.character(tcl('::loon::isKnownWidget', widget)))
-        
-        if (isLoon) TRUE
-        else FALSE
-    }
+
+    if(is.null(widget)) return(FALSE)
+    if(is.list(widget)) return(FALSE)
+
+    as.logical(as.character(tcl('::loon::isKnownWidget', widget)))
 }

--- a/R/R/loonGrob_l_facet_grid.R
+++ b/R/R/loonGrob_l_facet_grid.R
@@ -211,7 +211,7 @@ l_get_arrangeGrobArgs.l_facet_grid <- function(target) {
 
     # pack xlabel, title
     if(length(titlePathName) > 0) {
-        args$title <- paste0(as.character(tkcget(titlePathName, "-text")), collapse = " ")
+        args$top <- paste0(as.character(tkcget(titlePathName, "-text")), collapse = " ")
     }
     if(length(xLabelPathName) > 0) {
         args$bottom <- paste0(as.character(tkcget(xLabelPathName, "-text")), collapse = " ")

--- a/R/R/loonGrob_l_facet_wrap.R
+++ b/R/R/loonGrob_l_facet_wrap.R
@@ -134,7 +134,7 @@ l_get_arrangeGrobArgs.l_facet_wrap <- function(target) {
 
     # pack xlabel, title
     if(length(titlePathName) > 0) {
-        args$title <- paste0(as.character(tkcget(titlePathName, "-text")), collapse = " ")
+        args$top <- paste0(as.character(tkcget(titlePathName, "-text")), collapse = " ")
     }
     if(length(xLabelPathName) > 0) {
         args$bottom <- paste0(as.character(tkcget(xLabelPathName, "-text")), collapse = " ")

--- a/R/man/l_isLoonWidget.Rd
+++ b/R/man/l_isLoonWidget.Rd
@@ -10,7 +10,7 @@ l_isLoonWidget(widget)
 \item{widget}{widget path as a string or as an object handle}
 }
 \value{
-boolean, TRUE if the argument is a valid loon widget path, FALSE 
+boolean, TRUE if the argument is a valid loon widget path, FALSE
   otherwise
 }
 \description{

--- a/R/tests/testthat/test_facets.R
+++ b/R/tests/testthat/test_facets.R
@@ -4,7 +4,11 @@ context("test_facets")
 
 pdf(NULL)
 test_that("l_plot facets work with serialaxes glyph", {
-    p <- with(quakes, l_plot(long, lat, linkingGroup = "quakes"))
+    p <- with(quakes, l_plot(long, lat,
+                             xlab = "long",
+                             ylab = "lat",
+                             linkingGroup = "quakes",
+                             title = "earthquakes"))
     p["color"][quakes$mag < 5 & quakes$mag >= 4] <- "lightgreen"
     p["color"][quakes$mag < 6 & quakes$mag >= 5] <- "lightblue"
     p["color"][quakes$mag >= 6] <- "firebrick"
@@ -21,7 +25,9 @@ test_that("l_plot facets work with serialaxes glyph", {
 })
 
 test_that("l_plot facets work with  pointrange glyph", {
-    p <- l_plot(x = rep(1:3, 2), color = rep(c('red', 'blue', 'green'), 2), showScales=TRUE)
+    p <- l_plot(x = rep(1:3, 2),
+                color = rep(c('red', 'blue', 'green'), 2),
+                showScales=TRUE)
     g <- l_glyph_add_pointrange(p, ymin=(1:6)-(1:6)/5, ymax=(1:6)+(1:6)/5)
     p['glyph'][1:2] <- g
     f <- l_facet(p, layout = "grid", by = "color")

--- a/R/tests/testthat/test_isLoonWidget.R
+++ b/R/tests/testthat/test_isLoonWidget.R
@@ -1,0 +1,15 @@
+library(loon)
+context("test_isLoonWidget")
+
+pdf(NULL)
+test_that("test objects is a loon widget", {
+    expect_false(loon::l_isLoonWidget(NULL))
+    expect_false(loon::l_isLoonWidget(numeric(0L)))
+    expect_false(loon::l_isLoonWidget(NA))
+    expect_false(loon::l_isLoonWidget(NaN))
+    p <- l_plot()
+    expect_true(loon::l_isLoonWidget(p))
+    # An `l_compound` object is not a `loon` widget
+    pf <- l_plot(iris, by = iris$Species)
+    expect_false(loon::l_isLoonWidget(pf))
+})


### PR DESCRIPTION
1. Fix a bug: when we turn an `l_facet` object with titles to a  `loonGrob`, a bug shows. It is because in `arrangeGrob`, the title is called "top" not the "title". See details in d914f9a
2. `l_isLoonWidget` should accommodate NULL and return FALSE