### PR TITLE
fix scale issue

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: loon
 Type: Package
 Title: Interactive Statistical Data Visualization
-Version: 1.4.0
+Version: 1.4.1
 Date: 2022-03-12
 Authors@R: c(person(given = "Adrian", family = "Waddell", 
                     email = "adrian@waddell.ch", 
@@ -55,5 +55,5 @@ Suggests:
 BugReports: https://github.com/great-northern-diver/loon/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/R/NEWS.md
+++ b/R/NEWS.md
@@ -1,3 +1,11 @@
+# loon 1.4.1
+
+Address a minor issue:
+
+* Issue: Despite setting the `connectedScales` parameter as "none", every loon plot continued to share identical scales.
+
+* Cause: This was due to the `connectedScales` parameter not being passed into the function, leading to a failure in the logical check.
+
 # loon 1.4.0
 
 Minor changes and additions

--- a/R/R/layout_synchronizeSetting.R
+++ b/R/R/layout_synchronizeSetting.R
@@ -2,219 +2,221 @@ layout_synchronizeSetting <- function(plots, child,
                                       connectedScales = "cross",
                                       xrange, yrange, zoomX = 5/6, zoomY = 5/6, force = TRUE) {
 
-    if(force) {
-        # force scales
-        forceScales(plots = plots,
-                    xrange = xrange,
-                    yrange = yrange,
-                    zoomX = zoomX,
-                    zoomY = zoomY)
-    }
+  if(connectedScales == "none")
+    return(NULL)
 
-    if(connectedScales == "none") return(NULL)
+  if(force) {
+    # force scales
+    forceScales(plots = plots,
+                connectedScales = connectedScales,
+                xrange = xrange,
+                yrange = yrange,
+                zoomX = zoomX,
+                zoomY = zoomY)
+  }
 
-    layout_position <- layout_position(plots)
-    plotsHash <- list()
-    for (i in 1:length(plots)) {
+  layout_position <- layout_position(plots)
+  plotsHash <- list()
+  for (i in 1:length(plots)) {
 
-        tmpX <- which(layout_position[, "y"] == layout_position[i, "y"])
-        shareX <- tmpX[tmpX != i]
+    tmpX <- which(layout_position[, "y"] == layout_position[i, "y"])
+    shareX <- tmpX[tmpX != i]
 
-        tmpY <- which(layout_position[, "x"] == layout_position[i, "x"])
-        shareY <- tmpY[tmpY != i]
-        plotsHash[[paste("scatter_x_",
-                         plots[[i]],
-                         sep="")]] <- plots[shareX]
-        plotsHash[[paste("scatter_y_",
-                         plots[[i]],
-                         sep="")]] <- plots[shareY]
-    }
+    tmpY <- which(layout_position[, "x"] == layout_position[i, "x"])
+    shareY <- tmpY[tmpY != i]
+    plotsHash[[paste("scatter_x_",
+                     plots[[i]],
+                     sep="")]] <- plots[shareX]
+    plotsHash[[paste("scatter_y_",
+                     plots[[i]],
+                     sep="")]] <- plots[shareY]
+  }
 
-    busy <- FALSE
-    switch(
-        connectedScales,
-        "cross" = {
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomX <- W['zoomX']
-                    panX <- W['panX']
-                    deltaX <- W['deltaX']
+  busy <- FALSE
+  switch(
+    connectedScales,
+    "cross" = {
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomX <- W['zoomX']
+          panX <- W['panX']
+          deltaX <- W['deltaX']
 
-                    lapply(plotsHash[[paste("scatter_x_", W, sep="")]], function(p) {
-                        l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
-                    })
+          lapply(plotsHash[[paste("scatter_x_", W, sep="")]], function(p) {
+            l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
+          })
 
-                    zoomY <- W['zoomY']
-                    panY <- W['panY']
-                    deltaY <- W['deltaY']
+          zoomY <- W['zoomY']
+          panY <- W['panY']
+          deltaY <- W['deltaY']
 
-                    lapply(plotsHash[[paste("scatter_y_",W,sep="")]], function(p) {
-                        l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
-                    })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomX', 'panX', 'zoomY', 'panY', 'deltaX', 'deltaY'),
-                           synchronizeBindings)
-                   }
-            )
-        },
-        "row" = {
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomY <- W['zoomY']
-                    panY <- W['panY']
-                    deltaY <- W['deltaY']
-                    zoomX <- W['zoomX']
-                    panX <- W['panX']
-                    deltaX <- W['deltaX']
-
-                    lapply(plotsHash[[paste("scatter_y_",W,sep="")]], function(p) {
-                        l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY,
-                                    zoomX=zoomX, panX=panX, deltaX=deltaX)
-                    })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomY', 'panY', 'deltaY', 'zoomX', 'panX', 'deltaX'),
-                           synchronizeBindings)
-                   }
-            )
-        },
-        "column" = {
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomY <- W['zoomY']
-                    panY <- W['panY']
-                    deltaY <- W['deltaY']
-                    zoomX <- W['zoomX']
-                    panX <- W['panX']
-                    deltaX <- W['deltaX']
-
-                    lapply(plotsHash[[paste("scatter_x_",W,sep="")]], function(p) {
-                        l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY,
-                                    zoomX=zoomX, panX=panX, deltaX=deltaX)
-                    })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomY', 'panY', 'deltaY', 'zoomX', 'panX', 'deltaX'),
-                           synchronizeBindings)
-                   }
-            )
-        },
-        "both" = {
-
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomX <- W['zoomX']
-                    panX <- W['panX']
-                    deltaX <- W['deltaX']
-
-                    lapply(plots,
-                           function(p) {
-                               l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
-                           })
-
-                    zoomY <- W['zoomY']
-                    panY <- W['panY']
-                    deltaY <- W['deltaY']
-                    lapply(plots,
-                           function(p) {
-                               l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
-                           })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomX', 'panX', 'zoomY', 'panY', 'deltaX', 'deltaY'),
-                           synchronizeBindings)
-                   }
-            )
-        },
-        "y" = {
-
-
-            # fixed Y
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomY <- W['zoomY']
-                    panY <- W['panY']
-                    deltaY <- W['deltaY']
-                    lapply(plots,
-                           function(p) {
-                               l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
-                           })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomY', 'panY', 'deltaY'),
-                           synchronizeBindings)
-                   }
-            )
-
-        },
-        "x" = {
-            # fixed X
-            synchronizeBindings <- function(W) {
-                if (!busy) {
-                    busy <<- TRUE
-                    class(W) <- "loon"
-                    zoomX <- W['zoomX']
-                    panX <- W['panX']
-                    deltaX <- W['deltaX']
-
-                    lapply(plots,
-                           function(p) {
-                               l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
-                           })
-                    busy <<- FALSE
-                    tcl('update', 'idletasks')
-                }
-            }
-
-            lapply(plots,
-                   function(p) {
-                       tcl(p, 'systembind', 'state', 'add',
-                           c('zoomX', 'panX', 'deltaX'),
-                           synchronizeBindings)
-                   }
-            )
-
+          lapply(plotsHash[[paste("scatter_y_",W,sep="")]], function(p) {
+            l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
+          })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
         }
-    )
-    callbackFunctions$state[[paste(child,"synchronizeBindings", sep="_")]] <- synchronizeBindings
+      }
+
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomX', 'panX', 'zoomY', 'panY', 'deltaX', 'deltaY'),
+                   synchronizeBindings)
+             }
+      )
+    },
+    "row" = {
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomY <- W['zoomY']
+          panY <- W['panY']
+          deltaY <- W['deltaY']
+          zoomX <- W['zoomX']
+          panX <- W['panX']
+          deltaX <- W['deltaX']
+
+          lapply(plotsHash[[paste("scatter_y_",W,sep="")]], function(p) {
+            l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY,
+                        zoomX=zoomX, panX=panX, deltaX=deltaX)
+          })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
+        }
+      }
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomY', 'panY', 'deltaY', 'zoomX', 'panX', 'deltaX'),
+                   synchronizeBindings)
+             }
+      )
+    },
+    "column" = {
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomY <- W['zoomY']
+          panY <- W['panY']
+          deltaY <- W['deltaY']
+          zoomX <- W['zoomX']
+          panX <- W['panX']
+          deltaX <- W['deltaX']
+
+          lapply(plotsHash[[paste("scatter_x_",W,sep="")]], function(p) {
+            l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY,
+                        zoomX=zoomX, panX=panX, deltaX=deltaX)
+          })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
+        }
+      }
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomY', 'panY', 'deltaY', 'zoomX', 'panX', 'deltaX'),
+                   synchronizeBindings)
+             }
+      )
+    },
+    "both" = {
+
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomX <- W['zoomX']
+          panX <- W['panX']
+          deltaX <- W['deltaX']
+
+          lapply(plots,
+                 function(p) {
+                   l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
+                 })
+
+          zoomY <- W['zoomY']
+          panY <- W['panY']
+          deltaY <- W['deltaY']
+          lapply(plots,
+                 function(p) {
+                   l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
+                 })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
+        }
+      }
+
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomX', 'panX', 'zoomY', 'panY', 'deltaX', 'deltaY'),
+                   synchronizeBindings)
+             }
+      )
+    },
+    "y" = {
+
+
+      # fixed Y
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomY <- W['zoomY']
+          panY <- W['panY']
+          deltaY <- W['deltaY']
+          lapply(plots,
+                 function(p) {
+                   l_configure(p, zoomY=zoomY, panY=panY, deltaY=deltaY)
+                 })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
+        }
+      }
+
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomY', 'panY', 'deltaY'),
+                   synchronizeBindings)
+             }
+      )
+
+    },
+    "x" = {
+      # fixed X
+      synchronizeBindings <- function(W) {
+        if (!busy) {
+          busy <<- TRUE
+          class(W) <- "loon"
+          zoomX <- W['zoomX']
+          panX <- W['panX']
+          deltaX <- W['deltaX']
+
+          lapply(plots,
+                 function(p) {
+                   l_configure(p, zoomX=zoomX, panX=panX, deltaX=deltaX)
+                 })
+          busy <<- FALSE
+          tcl('update', 'idletasks')
+        }
+      }
+
+      lapply(plots,
+             function(p) {
+               tcl(p, 'systembind', 'state', 'add',
+                   c('zoomX', 'panX', 'deltaX'),
+                   synchronizeBindings)
+             }
+      )
+
+    }
+  )
+  callbackFunctions$state[[paste(child,"synchronizeBindings", sep="_")]] <- synchronizeBindings
 }
 


### PR DESCRIPTION
Address a minor issue:

* Issue: Despite setting the `connectedScales` parameter as "none", every loon plot continued to share identical scales.

* Cause: This was due to the `connectedScales` parameter not being passed into the function, leading to a failure in the logical check.