### PR TITLE
configure script and  .onload() 

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: loon
 Type: Package
 Title: Interactive Statistical Data Visualization
-Version: 1.4.2
-Date: 2025-05-26
+Version: 1.4.3
+Date: 2025-06-05
 Authors@R: c(person(given = "Adrian", family = "Waddell", 
                     email = "adrian@waddell.ch", 
                     role = c("aut")),
@@ -19,7 +19,7 @@ Authors@R: c(person(given = "Adrian", family = "Waddell",
 URL: https://great-northern-diver.github.io/loon/
 Description: An extendable toolkit for interactive data visualization and exploration.
 License: GPL-2
-SystemRequirements: Tcl/Tk = 8.6
+SystemRequirements: Tcl/Tk (>= 8.6, < 9.0)
 Depends:
     R (>= 3.5.0),
     methods,

--- a/R/R/onLoad.R
+++ b/R/R/onLoad.R
@@ -20,7 +20,17 @@
         ##      }
         ##")
     }
+    version <- as.character(tcltk::tclVersion())
+    major <- as.integer(strsplit(version, "\\.")[[1]][1])
+    minor <- as.integer(strsplit(version, "\\.")[[1]][2])
 
+    if (!(major == 8 && minor >= 6)) {
+        stop(sprintf("Tcl version 8.6 required; found %s", version), call. = FALSE)
+    }
+
+    if (major >= 9) {
+        stop(sprintf("Tcl version < 9.0 required; found %s; Tcl version >= 9.0 coming", version), call. = FALSE)
+    }
 
 
     ## Load Tcl package

--- a/R/configure
+++ b/R/configure
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# ------------------------------------------------------------------
+# configure  —  Check that Tcl and Tk are version 8.6 ≤ X < 9.0
+# ------------------------------------------------------------------
+
+set -e
+
+echo "Checking for Tcl/Tk version ≥ 8.6 and < 9.0..."
+
+# ------------------------------------------------------------------
+# Helper: compare two “dotted” version strings.
+#
+# version_ge A B  returns true (exit code 0) if A ≥ B lexicographically
+#                  (using sort -V logic), false otherwise.
+# ------------------------------------------------------------------
+version_ge() {
+  [ "$1" = "$2" ] && return 0
+  lower=$(printf '%s\n' "$1" "$2" | sort -V | head -n1)
+  [ "$lower" = "$2" ]
+}
+
+# ------------------------------------------------------------------
+# 1. Locate a Tcl interpreter (tclsh).  Fail if not found.
+# ------------------------------------------------------------------
+TCLSH=$(command -v tclsh || true)
+if [ -z "$TCLSH" ]; then
+  echo "ERROR: could not find 'tclsh' in PATH." 1>&2
+  exit 1
+fi
+
+# ------------------------------------------------------------------
+# 2. Query the Tcl version
+# ------------------------------------------------------------------
+TCL_VERSION=$("$TCLSH" <<EOF
+puts [info tclversion]
+EOF
+)
+
+# Trim whitespace/newlines
+TCL_VERSION=$(printf '%s\n' "$TCL_VERSION" | tr -d '[:space:]')
+
+echo "  Detected Tcl version: $TCL_VERSION"
+
+# ------------------------------------------------------------------
+# 3. Enforce 8.6 ≤ Tcl version < 9.0
+# ------------------------------------------------------------------
+
+# Case A: tcl < 8.6  → ERROR
+if ! version_ge "$TCL_VERSION" "8.6"; then
+  echo "ERROR: Tcl version $TCL_VERSION found, but ≥ 8.6 is required." 1>&2
+  exit 1
+fi
+
+# Case B: tcl ≥ 9.0 → ERROR
+if version_ge "$TCL_VERSION" "9.0"; then
+  echo "ERROR: Tcl version $TCL_VERSION found, but < 9.0 is required." 1>&2
+  exit 1
+fi
+
+echo "  Tcl version $TCL_VERSION is acceptable."
+
+# ------------------------------------------------------------------
+# 4. Query the Tk version (optional, if your package uses the Tk GUI)
+# ------------------------------------------------------------------
+#    We try loading Tk via the same tclsh.  If tk isn’t present,
+#    issue a warning (you can decide whether to treat missing Tk as error).
+# ------------------------------------------------------------------
+
+TK_VERSION=$("$TCLSH" <<EOF
+package require Tk
+puts [package present Tk]
+EOF
+) 2>/dev/null || TK_VERSION=""
+
+TK_VERSION=$(printf '%s\n' "$TK_VERSION" | tr -d '[:space:]')
+
+if [ -z "$TK_VERSION" ]; then
+  echo "WARNING: Could not detect a 'Tk' package from tclsh."
+  echo "         If 'loon' needs Tk at runtime, make sure Tk ≥ 8.6 < 9.0 is installed."
+else
+  echo "  Detected Tk version: $TK_VERSION"
+
+  # Case A: tk < 8.6  → ERROR
+  if ! version_ge "$TK_VERSION" "8.6"; then
+    echo "ERROR: Tk version $TK_VERSION found, but ≥ 8.6 is required." 1>&2
+    exit 1
+  fi
+
+  # Case B: tk ≥ 9.0 → ERROR
+  if version_ge "$TK_VERSION" "9.0"; then
+    echo "ERROR: Tk version $TK_VERSION found, but >= 8.6 and < 9.0 is required." 1>&2
+    exit 1
+  fi
+
+  echo "  Tk version $TK_VERSION is acceptable."
+fi
+
+exit 0
+

--- a/R/configure
+++ b/R/configure
@@ -1,99 +1,72 @@
 #!/bin/sh
 
-# ------------------------------------------------------------------
-# configure  —  Check that Tcl and Tk are version 8.6 ≤ X < 9.0
-# ------------------------------------------------------------------
+echo "=== Checking Tcl/Tk version (≥ 8.6 and < 9.0) ==="
 
-set -e
+USE_SOURCE=""
+TCLSH=""
 
-echo "Checking for Tcl/Tk version ≥ 8.6 and < 9.0..."
+# -----------------------------------------------------------------------------
+# 1) Try to detect Tcl/Tk version from R itself (if built with tcltk)
+# -----------------------------------------------------------------------------
+R_TCL_VERSION=$(Rscript -e 'if (capabilities("tcltk")) cat(tcltk::tclVersion())' 2>/dev/null)
 
-# ------------------------------------------------------------------
-# Helper: compare two “dotted” version strings.
-#
-# version_ge A B  returns true (exit code 0) if A ≥ B lexicographically
-#                  (using sort -V logic), false otherwise.
-# ------------------------------------------------------------------
-version_ge() {
-  [ "$1" = "$2" ] && return 0
-  lower=$(printf '%s\n' "$1" "$2" | sort -V | head -n1)
-  [ "$lower" = "$2" ]
-}
+if [ $? -eq 0 ] && [ -n "$R_TCL_VERSION" ]; then
+  MAJOR=$(echo "$R_TCL_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$R_TCL_VERSION" | cut -d. -f2)
+  echo "→ R reports Tcl version $R_TCL_VERSION"
 
-# ------------------------------------------------------------------
-# 1. Locate a Tcl interpreter (tclsh).  Fail if not found.
-# ------------------------------------------------------------------
-TCLSH=$(command -v tclsh || true)
-if [ -z "$TCLSH" ]; then
-  echo "ERROR: could not find 'tclsh' in PATH." 1>&2
-  exit 1
-fi
-
-# ------------------------------------------------------------------
-# 2. Query the Tcl version
-# ------------------------------------------------------------------
-TCL_VERSION=$("$TCLSH" <<EOF
-puts [info tclversion]
-EOF
-)
-
-# Trim whitespace/newlines
-TCL_VERSION=$(printf '%s\n' "$TCL_VERSION" | tr -d '[:space:]')
-
-echo "  Detected Tcl version: $TCL_VERSION"
-
-# ------------------------------------------------------------------
-# 3. Enforce 8.6 ≤ Tcl version < 9.0
-# ------------------------------------------------------------------
-
-# Case A: tcl < 8.6  → ERROR
-if ! version_ge "$TCL_VERSION" "8.6"; then
-  echo "ERROR: Tcl version $TCL_VERSION found, but ≥ 8.6 is required." 1>&2
-  exit 1
-fi
-
-# Case B: tcl ≥ 9.0 → ERROR
-if version_ge "$TCL_VERSION" "9.0"; then
-  echo "ERROR: Tcl version $TCL_VERSION found, but < 9.0 is required." 1>&2
-  exit 1
-fi
-
-echo "  Tcl version $TCL_VERSION is acceptable."
-
-# ------------------------------------------------------------------
-# 4. Query the Tk version (optional, if your package uses the Tk GUI)
-# ------------------------------------------------------------------
-#    We try loading Tk via the same tclsh.  If tk isn’t present,
-#    issue a warning (you can decide whether to treat missing Tk as error).
-# ------------------------------------------------------------------
-
-TK_VERSION=$("$TCLSH" <<EOF
-package require Tk
-puts [package present Tk]
-EOF
-) 2>/dev/null || TK_VERSION=""
-
-TK_VERSION=$(printf '%s\n' "$TK_VERSION" | tr -d '[:space:]')
-
-if [ -z "$TK_VERSION" ]; then
-  echo "WARNING: Could not detect a 'Tk' package from tclsh."
-  echo "         If 'loon' needs Tk at runtime, make sure Tk ≥ 8.6 < 9.0 is installed."
+  if [ "$MAJOR" -eq 8 ] && [ "$MINOR" -ge 6 ]; then
+    echo "✔ R Tcl version $R_TCL_VERSION is acceptable (≥ 8.6 < 9.0)."
+    USE_SOURCE="r"
+  elif [ "$MAJOR" -ge 9 ]; then
+    echo "✘ R Tcl version $R_TCL_VERSION is ≥ 9.0; not acceptable."
+    exit 1
+  else
+    echo "✘ R Tcl version $R_TCL_VERSION is < 8.6; not acceptable."
+    # Fall through to system check
+  fi
 else
-  echo "  Detected Tk version: $TK_VERSION"
+  echo "→ Could not detect Tcl/Tk via Rscript; falling back to system tclsh"
+fi
 
-  # Case A: tk < 8.6  → ERROR
-  if ! version_ge "$TK_VERSION" "8.6"; then
-    echo "ERROR: Tk version $TK_VERSION found, but ≥ 8.6 is required." 1>&2
+# -----------------------------------------------------------------------------
+# 2) Fall back to known tclsh paths
+# -----------------------------------------------------------------------------
+if [ -z "$USE_SOURCE" ]; then
+  for candidate in \
+      "$(command -v tclsh8 2>/dev/null)" \
+      "$(command -v tclsh 2>/dev/null)" \
+      /usr/local/opt/tcl-tk@8/bin/tclsh \
+      /opt/homebrew/opt/tcl-tk@8/bin/tclsh \
+      /usr/local/bin/tclsh \
+      /opt/homebrew/bin/tclsh; do
+
+    if [ -x "$candidate" ]; then
+      VERSION=$("$candidate" <<< 'puts [info tclversion]' 2>/dev/null)
+      if [ $? -eq 0 ]; then
+        MAJOR=$(echo "$VERSION" | cut -d. -f1)
+        MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+        echo "  → Found Tcl version $VERSION (from $candidate)"
+
+        if [ "$MAJOR" -eq 8 ] && [ "$MINOR" -ge 6 ]; then
+          TCLSH="$candidate"
+          USE_SOURCE="system"
+          echo "  ✔ Tcl version $VERSION is acceptable (≥ 8.6 < 9.0)."
+          break
+        elif [ "$MAJOR" -lt 8 ] || [ "$MAJOR" -eq 8 -a "$MINOR" -lt 6 ]; then
+          echo "  ✘ Tcl version $VERSION is < 8.6; not acceptable."
+        else
+          echo "  ✘ Tcl version $VERSION is ≥ 9.0; not acceptable."
+        fi
+      fi
+    fi
+  done
+
+  if [ -z "$TCLSH" ]; then
+    echo "ERROR: Could not find Tcl ≥ 8.6 and < 9.0 in R or system paths." 1>&2
     exit 1
   fi
-
-  # Case B: tk ≥ 9.0 → ERROR
-  if version_ge "$TK_VERSION" "9.0"; then
-    echo "ERROR: Tk version $TK_VERSION found, but >= 8.6 and < 9.0 is required." 1>&2
-    exit 1
-  fi
-
-  echo "  Tk version $TK_VERSION is acceptable."
 fi
 
 exit 0


### PR DESCRIPTION
Adding a configure script file and version check in .onload() 
Taking care to avoid use of Tcltk 9.0.1 until I have built an R with it and tested loon on it.

Eventually these changes will be undone once tcltk 9.0.1 has been thoroughly tested.
